### PR TITLE
Add support for "cubes".

### DIFF
--- a/src/_impl_bdd/_impl_boolean_ops.rs
+++ b/src/_impl_bdd/_impl_boolean_ops.rs
@@ -157,7 +157,7 @@ where
     struct Task {
         left: BddPointer,
         right: BddPointer,
-    };
+    }
 
     // `stack` is used to explore the two BDDs "side by side" in DFS-like manner. Each task
     // on the stack is a pair of nodes that needs to be fully processed before we are finished.

--- a/src/_impl_bdd/_impl_cube_ops.rs
+++ b/src/_impl_bdd/_impl_cube_ops.rs
@@ -1,0 +1,85 @@
+use crate::{Bdd, BddCube};
+use std::convert::TryFrom;
+
+impl Bdd {
+    /// Compute the *smallest* cube in the `Bdd`.
+    ///
+    /// The smallest cube is the one with the greatest amount of
+    /// fixed variables (i.e. the cube corresponds to the least
+    /// amount of valuations). If there are multiple min cubes,
+    /// the method places no guarantees on which cube is returned,
+    /// but should be deterministic.
+    pub fn min_cube(&self) -> BddCube {
+        if self.is_false() {
+            panic!("Calling `min_cube` on an empty Bdd.");
+        }
+        // A vector which contains the size (no. of free variables) of the min
+        // cube originating in the corresponding Bdd node, and which link is
+        // used in such cube (i.e. low=false, true=high).
+        let mut cube_sizes: Vec<(u16, bool)> = Vec::new();
+        // For leaves, the link does not really matter.
+        cube_sizes.push((0, true));
+        cube_sizes.push((0, true));
+        for node in self.nodes().skip(2) {
+            if node.low_link.is_zero() {
+                let high_link = usize::try_from(node.high_link.0).unwrap();
+                cube_sizes.push((cube_sizes[high_link].0 + 1, true));
+            } else if node.high_link.is_zero() {
+                let low_link = usize::try_from(node.low_link.0).unwrap();
+                cube_sizes.push((cube_sizes[low_link].0 + 1, false));
+            } else {
+                let low_link = usize::try_from(node.low_link.0).unwrap();
+                let high_link = usize::try_from(node.high_link.0).unwrap();
+                if cube_sizes[high_link].0 > cube_sizes[low_link].0 {
+                    cube_sizes.push((cube_sizes[high_link].0 + 1, true));
+                } else {
+                    cube_sizes.push((cube_sizes[low_link].0 + 1, false));
+                }
+            }
+        }
+        let mut result = BddCube::new(self.num_vars());
+        let mut pointer = self.root_pointer();
+        while !pointer.is_one() {
+            let var = self.var_of(pointer);
+            let value = cube_sizes[pointer.to_index()].1;
+            result.set(var, value);
+            pointer = if value {
+                self.high_link_of(pointer)
+            } else {
+                self.low_link_of(pointer)
+            }
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::_test_util::mk_small_test_bdd;
+    use crate::{BddVariable, BddVariableSet};
+
+    #[test]
+    fn test_min_cube_basic() {
+        let bdd = mk_small_test_bdd();
+        let cube = bdd.min_cube();
+        assert_eq!(
+            cube.values(),
+            vec![(BddVariable(2), true), (BddVariable(3), false)]
+        );
+    }
+
+    #[test]
+    fn test_min_cube_complex() {
+        let universe = BddVariableSet::new_anonymous(5);
+        let bdd = universe.eval_expression_string("x_1 & ((x_2 & !x_3 & x_4) | x_3)");
+        assert_eq!(
+            bdd.min_cube().values(),
+            vec![
+                (BddVariable(1), true),
+                (BddVariable(2), true),
+                (BddVariable(3), false),
+                (BddVariable(4), true)
+            ]
+        );
+    }
+}

--- a/src/_impl_bdd/mod.rs
+++ b/src/_impl_bdd/mod.rs
@@ -13,3 +13,6 @@ pub mod _impl_serialisation;
 
 /// **(internal)** Implementation of some basic internal utility methods for `Bdd`s.
 pub mod _impl_util;
+
+/// **(internal)** Provides operations for extracting cubes from `Bdds`.
+pub mod _impl_cube_ops;

--- a/src/_impl_bdd_cube.rs
+++ b/src/_impl_bdd_cube.rs
@@ -1,0 +1,31 @@
+use crate::{BddCube, BddVariable};
+use std::convert::TryFrom;
+
+impl BddCube {
+
+    /// Create a new empty cube over the given number of variables.
+    pub fn new(num_vars: usize) -> BddCube {
+        BddCube(vec![None; num_vars])
+    }
+
+    /// Fix value of the desired [variable] to the given [value].
+    pub fn set(&mut self, variable: BddVariable, value: bool) {
+        self.0[usize::from(variable.0)] = Some(value);
+    }
+
+    /// Free restriction on the specified [variable].
+    pub fn unset(&mut self, variable: BddVariable) {
+        self.0[usize::from(variable.0)] = None;
+    }
+
+    /// Return a vector of values which are fixed in this particular cube.
+    /// The vector is sorted, starting with the "smallest" variable.
+    pub fn values(&self) -> Vec<(BddVariable, bool)> {
+        self.0.iter().enumerate().filter_map(|(i, v)| {
+            v.map(|value| {
+                (BddVariable(u16::try_from(i).unwrap()), value)
+            })
+        }).collect()
+    }
+
+}

--- a/src/_impl_bdd_cube.rs
+++ b/src/_impl_bdd_cube.rs
@@ -2,10 +2,9 @@ use crate::{BddCube, BddVariable};
 use std::convert::TryFrom;
 
 impl BddCube {
-
     /// Create a new empty cube over the given number of variables.
-    pub fn new(num_vars: usize) -> BddCube {
-        BddCube(vec![None; num_vars])
+    pub fn new(num_vars: u16) -> BddCube {
+        BddCube(vec![None; usize::from(num_vars)])
     }
 
     /// Fix value of the desired [variable] to the given [value].
@@ -21,11 +20,10 @@ impl BddCube {
     /// Return a vector of values which are fixed in this particular cube.
     /// The vector is sorted, starting with the "smallest" variable.
     pub fn values(&self) -> Vec<(BddVariable, bool)> {
-        self.0.iter().enumerate().filter_map(|(i, v)| {
-            v.map(|value| {
-                (BddVariable(u16::try_from(i).unwrap()), value)
-            })
-        }).collect()
+        self.0
+            .iter()
+            .enumerate()
+            .filter_map(|(i, v)| v.map(|value| (BddVariable(u16::try_from(i).unwrap()), value)))
+            .collect()
     }
-
 }

--- a/src/_impl_bdd_variable_set.rs
+++ b/src/_impl_bdd_variable_set.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl BddVariableSet {
-    /// Create a new `BddVariableSet` with anonymous variables $(x_1, \ldots, x_n)$ where $n$ is
+    /// Create a new `BddVariableSet` with anonymous variables $(x_0, \ldots, x_n)$ where $n$ is
     /// the `num_vars` parameter.
     pub fn new_anonymous(num_vars: u16) -> BddVariableSet {
         if num_vars >= (std::u16::MAX - 1) {
@@ -121,7 +121,6 @@ impl BddVariableSet {
         }
         result
     }
-
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ mod _impl_bdd_pointer;
 /// **(internal)** Implementation of the `BddValuation`.
 mod _impl_bdd_valuation;
 
+/// **(internal)** Implementation of the `BddCube`.
+mod _impl_bdd_cube;
+
 /// **(internal)** Implementation of the `BddValuationsIterator`.
 mod _impl_bdd_satisfying_valuations;
 
@@ -94,6 +97,13 @@ pub struct BddVariable(u16);
 /// in some corresponding valuation and get a `true/false` result.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct BddValuation(Vec<bool>);
+
+/// A cube is a partial assignment of the Boolean variables in a BDD.
+///
+/// It represents one path in the BDD (undefined values are the variables
+/// which were not decided upon).
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+pub struct BddCube(Vec<Option<bool>>);
 
 /// Exhaustively iterates over all valuations with a certain number of variables.
 ///


### PR DESCRIPTION
A *cube* represents a partial assignment of variables in a `Bdd`. They are useful alternative to `BddValuation`, which always needs to fix all variables. In particular, they are useful for quickly building `Bdd` objects from AND-clauses (e.g. `x && !y && z`), and for inspecting contents of a `Bdd` (e.g. `min_cube` and `max_cube`).

Before merging, we should make sure the API is ok as is (i.e. we are not missing some obviously useful methods - for example a way to create a `BddCube` from iterator or something like that) and that everything is properly documented. Also, we should update the branch from master.