### PR TITLE
Updated valuations and paths API.

### DIFF
--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -2,7 +2,7 @@ use crate::{Bdd, BddPartialValuation, BddValuation};
 
 /// Utilities for extracting interesting valuations and paths from a `Bdd`.
 impl Bdd {
-    /// Return the lexicographically smallest satisfying valuation of this `Bdd`.
+    /// Return the lexicographically first satisfying valuation of this `Bdd`.
     ///
     /// (In this context, lexicographically means `0 < 1`, with greatest variable id
     /// being the most significant).
@@ -25,7 +25,7 @@ impl Bdd {
         Some(valuation)
     }
 
-    /// Return the lexicographically largest satisfying valuation of this `Bdd`.
+    /// Return the lexicographically last satisfying valuation of this `Bdd`.
     ///
     /// (In this context, lexicographically means `0 < 1`, with greatest variable id
     /// being the most significant).
@@ -48,7 +48,7 @@ impl Bdd {
         Some(valuation)
     }
 
-    /// Return the lexicographically smallest path in this `Bdd`, represented as
+    /// Return the lexicographically fist path in this `Bdd`, represented as
     /// a *conjunctive* clause.
     pub fn first_path(&self) -> Option<BddPartialValuation> {
         if self.is_false() {
@@ -70,7 +70,7 @@ impl Bdd {
         Some(valuation)
     }
 
-    /// Return the lexicographically largest path in this `Bdd`, represented as
+    /// Return the lexicographically last path in this `Bdd`, represented as
     /// a *conjunctive* clause.
     pub fn last_path(&self) -> Option<BddPartialValuation> {
         if self.is_false() {
@@ -90,6 +90,114 @@ impl Bdd {
             } else {
                 valuation.set_value(self.var_of(node), true);
                 node = self.high_link_of(node);
+            }
+        }
+
+        Some(valuation)
+    }
+
+    /// Return a valuation in this `Bdd` that contains the greatest amount of positive literals.
+    ///
+    /// If such valuation is not unique, the method should return the one that is first
+    /// lexicographically.
+    pub fn most_positive_valuation(&self) -> Option<BddValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut cache = Vec::with_capacity(self.size());
+        cache.push((0, true));
+        cache.push((0, true));
+
+        for i in self.pointers().skip(2) {
+            let i_var = self.var_of(i);
+            let low_link = self.low_link_of(i);
+            let high_link = self.high_link_of(i);
+
+            // Parenthesis to avoid a chance of overflow.
+            let low_link_diff =
+                cache[low_link.to_index()].0 + ((self.var_of(low_link).0 - i_var.0) - 1);
+            let high_link_diff =
+                cache[high_link.to_index()].0 + ((self.var_of(high_link).0 - i_var.0) - 1);
+
+            let result = if low_link.is_zero() && high_link.is_zero() {
+                panic!("Non canonical BDD.")
+            } else if low_link.is_zero() {
+                (high_link_diff + 1, true)
+            } else if high_link.is_zero() {
+                (low_link_diff, false)
+            } else if high_link_diff + 1 > low_link_diff {
+                (high_link_diff + 1, true)
+            } else {
+                (low_link_diff, false)
+            };
+
+            cache.push(result);
+        }
+
+        let mut valuation = BddValuation::all_true(self.num_vars());
+        let mut node = self.root_pointer();
+        while !node.is_terminal() {
+            let (_, child) = cache[node.to_index()];
+            if child {
+                node = self.high_link_of(node);
+            } else {
+                valuation.clear(self.var_of(node));
+                node = self.low_link_of(node);
+            }
+        }
+
+        Some(valuation)
+    }
+
+    /// Return a valuation in this `Bdd` that contains the greatest amount of negative literals.
+    ///
+    /// If such valuation is not unique, the method should return the one that is first
+    /// lexicographically.
+    pub fn most_negative_valuation(&self) -> Option<BddValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut cache = Vec::with_capacity(self.size());
+        cache.push((0, true));
+        cache.push((0, true));
+
+        for i in self.pointers().skip(2) {
+            let i_var = self.var_of(i);
+            let low_link = self.low_link_of(i);
+            let high_link = self.high_link_of(i);
+
+            // Parenthesis to avoid a chance of overflow.
+            let low_link_diff =
+                cache[low_link.to_index()].0 + ((self.var_of(low_link).0 - i_var.0) - 1);
+            let high_link_diff =
+                cache[high_link.to_index()].0 + ((self.var_of(high_link).0 - i_var.0) - 1);
+
+            let result = if low_link.is_zero() && high_link.is_zero() {
+                panic!("Non canonical BDD.")
+            } else if low_link.is_zero() {
+                (high_link_diff, true)
+            } else if high_link.is_zero() {
+                (low_link_diff + 1, false)
+            } else if high_link_diff > low_link_diff + 1 {
+                (high_link_diff, true)
+            } else {
+                (low_link_diff + 1, false)
+            };
+
+            cache.push(result);
+        }
+
+        let mut valuation = BddValuation::all_false(self.num_vars());
+        let mut node = self.root_pointer();
+        while !node.is_terminal() {
+            let (_, child) = cache[node.to_index()];
+            if child {
+                valuation.set(self.var_of(node));
+                node = self.high_link_of(node);
+            } else {
+                node = self.low_link_of(node);
             }
         }
 
@@ -131,5 +239,17 @@ mod tests {
 
         assert_eq!(Some(first_path), bdd.first_path());
         assert_eq!(Some(last_path), bdd.last_path());
+    }
+
+    #[test]
+    fn most_positive_negative_valuation() {
+        let vars = BddVariableSet::new_anonymous(5);
+        let bdd = vars.eval_expression_string("x_0 & (!x_2 | x_3) & !x_4");
+
+        let most_positive_valuation = BddValuation(vec![true, true, true, true, false]);
+        let most_negative_valuation = BddValuation(vec![true, false, false, false, false]);
+
+        assert_eq!(Some(most_positive_valuation), bdd.most_positive_valuation());
+        assert_eq!(Some(most_negative_valuation), bdd.most_negative_valuation());
     }
 }

--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -1,0 +1,71 @@
+use crate::{Bdd, BddPartialValuation, BddValuation};
+
+/// Utilities for extracting interesting valuations and paths from a `Bdd`.
+impl Bdd {
+    /// Return the lexicographically smallest satisfying valuation of this `Bdd`.
+    ///
+    /// (In this context, lexicographically means `0 < 1`, with greatest variable id
+    /// being the most significant).
+    pub fn first_valuation(&self) -> Option<BddValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut valuation = BddValuation::all_false(self.num_vars());
+        let mut node = self.root_pointer();
+        while !node.is_terminal() {
+            if self.low_link_of(node).is_zero() {
+                valuation.set(self.var_of(node));
+                node = self.high_link_of(node);
+            } else {
+                node = self.low_link_of(node);
+            }
+        }
+
+        Some(valuation)
+    }
+
+    /// Return the lexicographically largest satisfying valuation of this `Bdd`.
+    ///
+    /// (In this context, lexicographically means `0 < 1`, with greatest variable id
+    /// being the most significant).
+    pub fn last_valuation(&self) -> Option<BddValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut valuation = BddValuation::all_true(self.num_vars());
+        let mut node = self.root_pointer();
+        while !node.is_terminal() {
+            if self.high_link_of(node).is_zero() {
+                valuation.clear(self.var_of(node));
+                node = self.low_link_of(node);
+            } else {
+                node = self.high_link_of(node);
+            }
+        }
+
+        Some(valuation)
+    }
+
+    /// Return the lexicographically smallest path in this `Bdd`, represented as
+    /// a *conjunctive* clause.
+    pub fn first_path(&self) -> Option<BddPartialValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut valuation = BddPartialValuation::empty();
+        let mut node = self.root_pointer();
+        while !node.is_terminal() {
+            if self.low_link_of(node).is_zero() {
+                valuation.set_value(self.var_of(node), true);
+                node = self.high_link_of(node);
+            } else {
+                node = self.low_link_of(node);
+            }
+        }
+
+        Some(valuation)
+    }
+}

--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -62,10 +62,74 @@ impl Bdd {
                 valuation.set_value(self.var_of(node), true);
                 node = self.high_link_of(node);
             } else {
+                valuation.set_value(self.var_of(node), false);
                 node = self.low_link_of(node);
             }
         }
 
         Some(valuation)
+    }
+
+    /// Return the lexicographically largest path in this `Bdd`, represented as
+    /// a *conjunctive* clause.
+    pub fn last_path(&self) -> Option<BddPartialValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        if self.is_false() {
+            return None;
+        }
+
+        let mut valuation = BddPartialValuation::empty();
+        let mut node = self.root_pointer();
+        while !node.is_terminal() {
+            if self.high_link_of(node).is_zero() {
+                valuation.set_value(self.var_of(node), false);
+                node = self.low_link_of(node);
+            } else {
+                valuation.set_value(self.var_of(node), true);
+                node = self.high_link_of(node);
+            }
+        }
+
+        Some(valuation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BddPartialValuation, BddValuation, BddVariableSet};
+
+    #[test]
+    fn first_last_valuation() {
+        let vars = BddVariableSet::new_anonymous(5);
+        let bdd = vars.eval_expression_string("x_0 & (!x_2 | x_3) & !x_4");
+
+        let first_valuation = BddValuation(vec![true, false, false, false, false]);
+        let last_valuation = BddValuation(vec![true, true, true, true, false]);
+
+        assert_eq!(Some(first_valuation), bdd.first_valuation());
+        assert_eq!(Some(last_valuation), bdd.last_valuation());
+    }
+
+    #[test]
+    fn first_last_path() {
+        let vars = BddVariableSet::new_anonymous(5);
+        let v = vars.variables();
+        let bdd = vars.eval_expression_string("x_0 & (!x_2 | x_3) & !x_4");
+
+        let first_path =
+            BddPartialValuation::from_values(&[(v[0], true), (v[2], false), (v[4], false)]);
+
+        let last_path = BddPartialValuation::from_values(&[
+            (v[0], true),
+            (v[2], true),
+            (v[3], true),
+            (v[4], false),
+        ]);
+
+        assert_eq!(Some(first_path), bdd.first_path());
+        assert_eq!(Some(last_path), bdd.last_path());
     }
 }

--- a/src/_impl_bdd/mod.rs
+++ b/src/_impl_bdd/mod.rs
@@ -13,3 +13,7 @@ pub mod _impl_serialisation;
 
 /// **(internal)** Implementation of some basic internal utility methods for `Bdd`s.
 pub mod _impl_util;
+
+/// **(internal)** Implementation of some utility methods for extracting interesting
+/// valuations and paths from a `Bdd`.
+pub mod _impl_valuation_utils;

--- a/src/_impl_bdd_partial_valuation.rs
+++ b/src/_impl_bdd_partial_valuation.rs
@@ -65,6 +65,22 @@ impl BddPartialValuation {
         }
         &mut self.0[index]
     }
+
+    /// Returns true if the values set in this partial valuation match the values fixed in the
+    /// other given valuation. I.e. the two valuations agree on fixed values in `valuation`.
+    ///
+    /// In other words `this >= valuation` in terms of specificity.
+    pub fn extends(&self, valuation: &BddPartialValuation) -> bool {
+        for var_id in 0..(valuation.0.len() as u16) {
+            let var = BddVariable(var_id);
+            let expected = valuation.get_value(var);
+            if expected.is_some() && self.get_value(var) != expected {
+                return false;
+            }
+        }
+
+        true
+    }
 }
 
 impl Default for BddPartialValuation {
@@ -84,6 +100,7 @@ mod tests {
         let v5 = BddVariable(5);
 
         let mut a = BddPartialValuation::default();
+        assert!(!a.has_value(v1));
         a.set_value(v1, true);
         assert!(a.has_value(v1));
         assert_eq!(Some(true), a.get_value(v1));

--- a/src/_impl_bdd_path_iterator.rs
+++ b/src/_impl_bdd_path_iterator.rs
@@ -1,0 +1,161 @@
+use crate::{Bdd, BddPartialValuation, BddPathIterator, BddPointer};
+
+impl BddPathIterator<'_> {
+    pub fn new(bdd: &Bdd) -> BddPathIterator {
+        if bdd.is_false() {
+            BddPathIterator {
+                bdd,
+                stack: Vec::new(),
+            }
+        } else {
+            let mut stack = Vec::new();
+            stack.push(bdd.root_pointer());
+            continue_path(bdd, &mut stack); // Compute the first valid path.
+            BddPathIterator { bdd, stack }
+        }
+    }
+}
+
+impl Iterator for BddPathIterator<'_> {
+    type Item = BddPartialValuation;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.stack.is_empty() {
+            None
+        } else {
+            let item = make_clause(self.bdd, &self.stack);
+
+            // Now, we need to pop the path until we find a node with a valid successor,
+            // and then extend the path using `continue_path`.
+
+            let mut last_child = self.stack.pop().unwrap();
+
+            while let Some(top) = self.stack.last() {
+                if self.bdd.low_link_of(*top) == last_child {
+                    // Try to advance to the high link.
+                    if self.bdd.high_link_of(*top).is_zero() {
+                        // If high link is zero, we cannot advance and have to pop.
+                        last_child = *top;
+                        self.stack.pop();
+                    } else {
+                        // This is a sanity check which prevents the method from looping on
+                        // non-canonical BDDs.
+                        if self.bdd.low_link_of(*top) == self.bdd.high_link_of(*top) {
+                            panic!("The BDD is not canonical.");
+                        }
+
+                        let new_entry = self.bdd.high_link_of(*top);
+                        self.stack.push(new_entry);
+                        continue_path(self.bdd, &mut self.stack);
+                        break;
+                    }
+                } else if self.bdd.high_link_of(*top) == last_child {
+                    // Both low and high links have been processed,
+                    // so we can only pop to the next node.
+                    last_child = *top;
+                    self.stack.pop();
+                } else {
+                    // Just a sanity check. This should be unreachable.
+                    unreachable!("Invalid path data in iterator.");
+                }
+            }
+
+            // Here, either a path was found and extended, or the stack is empty and this was
+            // the last item.
+
+            Some(item)
+        }
+    }
+}
+
+/// **(internal)** Given a prefix of a path in a BDD, continue the prefix, always choosing
+/// the low link unless it leads to a false leaf.
+///
+/// The input path must be non-empty.
+fn continue_path(bdd: &Bdd, path: &mut Vec<BddPointer>) {
+    assert!(!path.is_empty());
+    loop {
+        let top = *path.last().unwrap();
+        if top.is_one() {
+            return;
+        }
+
+        if !bdd.low_link_of(top).is_zero() {
+            path.push(bdd.low_link_of(top));
+        } else if !bdd.high_link_of(top).is_zero() {
+            path.push(bdd.high_link_of(top));
+        } else {
+            panic!("The given BDD is not canonical.");
+        }
+    }
+}
+
+/// **(internal)** Convert a path in a `Bdd` saved as a stack into a clause.
+///
+/// The path must end with a pointer to the one-terminal node.
+fn make_clause(bdd: &Bdd, path: &[BddPointer]) -> BddPartialValuation {
+    let mut result = BddPartialValuation::empty();
+    for i in 0..(path.len() - 1) {
+        let this_node = path[i];
+        let next_node = path[i + 1];
+        let var = bdd.var_of(this_node);
+
+        if bdd.low_link_of(this_node) == next_node {
+            result.set_value(var, false);
+        } else if bdd.high_link_of(this_node) == next_node {
+            result.set_value(var, true);
+        } else {
+            panic!("Path {:?} is not valid in BDD {:?}", path, bdd);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{Bdd, BddPartialValuation, BddPathIterator, BddVariable, BddVariableSet};
+
+    #[test]
+    fn bdd_path_iterator_trivial() {
+        let ff = Bdd::mk_false(10);
+        assert_eq!(0, BddPathIterator::new(&ff).count());
+
+        let tt = Bdd::mk_true(10);
+        assert_eq!(1, BddPathIterator::new(&tt).count());
+
+        let tt = Bdd::mk_true(0);
+        assert_eq!(1, BddPathIterator::new(&tt).count());
+
+        let clause =
+            BddPartialValuation::from_values(&[(BddVariable(1), true), (BddVariable(2), false)]);
+        let vars = BddVariableSet::new_anonymous(10);
+        assert_eq!(
+            1,
+            BddPathIterator::new(&vars.mk_conjunctive_clause(&clause)).count()
+        );
+        assert_eq!(
+            2,
+            BddPathIterator::new(&vars.mk_disjunctive_clause(&clause)).count()
+        );
+    }
+
+    #[test]
+    fn bdd_path_iterator() {
+        let vars = BddVariableSet::new_anonymous(5);
+        let v = vars.variables();
+
+        let c1 = BddPartialValuation::from_values(&[(v[0], true), (v[1], false)]);
+        let c2 = BddPartialValuation::from_values(&[(v[1], true), (v[3], false)]);
+        let c3 = BddPartialValuation::from_values(&[(v[2], false), (v[4], true)]);
+        let bdd = vars.mk_dnf(&[c1.clone(), c2.clone(), c3.clone()]);
+
+        // println!("{}", bdd.to_dot_string(&vars, true));
+        // Counted manually in the .dot graph:
+        assert_eq!(8, BddPathIterator::new(&bdd).count());
+
+        BddPathIterator::new(&bdd).for_each(|path| {
+            assert!(path.extends(&c1) || path.extends(&c2) || path.extends(&c3));
+        });
+    }
+}

--- a/src/_impl_bdd_path_iterator.rs
+++ b/src/_impl_bdd_path_iterator.rs
@@ -8,8 +8,7 @@ impl BddPathIterator<'_> {
                 stack: Vec::new(),
             }
         } else {
-            let mut stack = Vec::new();
-            stack.push(bdd.root_pointer());
+            let mut stack = vec![bdd.root_pointer()];
             continue_path(bdd, &mut stack); // Compute the first valid path.
             BddPathIterator { bdd, stack }
         }

--- a/src/_impl_bdd_satisfying_valuations.rs
+++ b/src/_impl_bdd_satisfying_valuations.rs
@@ -3,6 +3,10 @@ use crate::{
 };
 
 impl Bdd {
+    /// Create an iterator that goes through all the satisfying valuations of this `Bdd`.
+    ///
+    /// Note that the number of such valuations can be substantial and can be approximated
+    /// using `Bdd.cardinality`.
     pub fn sat_valuations(&self) -> BddSatisfyingValuations {
         let mut path_iter = BddPathIterator::new(self);
         let val_iter = if let Some(first) = path_iter.next() {
@@ -16,6 +20,15 @@ impl Bdd {
             paths: path_iter,
             valuations: val_iter,
         }
+    }
+
+    /// Create an iterator that goes through all paths of this `Bdd`. Each path is represented
+    /// as a *conjunctive clause* in the form of `BddPartialValuation`.
+    ///
+    /// The whole formula represented by a `Bdd` can be then seen as a disjunction of these
+    /// clauses/paths.
+    pub fn paths(&self) -> BddPathIterator {
+        BddPathIterator::new(self)
     }
 }
 

--- a/src/_impl_bdd_satisfying_valuations.rs
+++ b/src/_impl_bdd_satisfying_valuations.rs
@@ -39,15 +39,13 @@ impl Iterator for BddSatisfyingValuations<'_> {
         let next_valuation = self.valuations.next();
         if next_valuation.is_some() {
             next_valuation
+        } else if let Some(next_path) = self.paths.next() {
+            self.valuations = ValuationsOfClauseIterator::new(next_path, self.bdd.num_vars());
+            // A new valuations iterator is never empty unless created using the `empty` constructor.
+            self.valuations.next()
         } else {
-            if let Some(next_path) = self.paths.next() {
-                self.valuations = ValuationsOfClauseIterator::new(next_path, self.bdd.num_vars());
-                // A new valuations iterator is never empty unless created using the `empty` constructor.
-                self.valuations.next()
-            } else {
-                // We are done.
-                None
-            }
+            // We are done.
+            None
         }
     }
 }

--- a/src/_impl_bdd_satisfying_valuations.rs
+++ b/src/_impl_bdd_satisfying_valuations.rs
@@ -1,127 +1,21 @@
-use crate::{Bdd, BddPointer, BddSatisfyingValuations, BddValuation, BddVariable};
+use crate::{
+    Bdd, BddPathIterator, BddSatisfyingValuations, BddValuation, ValuationsOfClauseIterator,
+};
 
 impl Bdd {
     pub fn sat_valuations(&self) -> BddSatisfyingValuations {
+        let mut path_iter = BddPathIterator::new(self);
+        let val_iter = if let Some(first) = path_iter.next() {
+            ValuationsOfClauseIterator::new(first, self.num_vars())
+        } else {
+            // This is a special case for the `false` BDD.
+            ValuationsOfClauseIterator::empty()
+        };
         BddSatisfyingValuations {
             bdd: self,
-            continuation: if self.is_false() {
-                None
-            } else {
-                Some(self.first_sat_path())
-            },
+            paths: path_iter,
+            valuations: val_iter,
         }
-    }
-
-    /// **(internal)** Find first satisfying path in the Bdd, its path mask (bits where the path
-    /// has fixed values) and smallest valuation on this path.
-    fn first_sat_path(&self) -> (Vec<BddPointer>, BddValuation, BddValuation) {
-        let mut sat_path = Vec::new();
-        let mut path_mask = BddValuation::all_false(self.num_vars());
-        let mut first_valuation = BddValuation::all_false(self.num_vars());
-        sat_path.push(self.root_pointer());
-        self.continue_sat_path(&mut sat_path, &mut path_mask, &mut first_valuation);
-        (sat_path, path_mask, first_valuation)
-    }
-
-    /// **(internal)** Take last node on given `sat_path` and find the first satisfiable path that follows from it.
-    ///
-    /// When this function returns, last pointer in `sat_path` is the one pointer.
-    ///
-    /// Assumes `path_mask` and `first_valuation` is cleared for every variable greater than `varOf(last(sat_path))`.
-    fn continue_sat_path(
-        &self,
-        sat_path: &mut Vec<BddPointer>,
-        path_mask: &mut BddValuation,
-        first_valuation: &mut BddValuation,
-    ) {
-        while let Some(top) = sat_path.last() {
-            if top.is_zero() {
-                panic!("No SAT path!");
-            } else if top.is_one() {
-                return; // Found sat path.
-            } else {
-                let var = self.var_of(*top);
-                let low = self.low_link_of(*top);
-                let high = self.high_link_of(*top);
-                path_mask.set(var);
-                if !low.is_zero() {
-                    sat_path.push(low);
-                } else {
-                    // Can't follow low; follow high.
-                    assert!(!high.is_zero());
-                    sat_path.push(high);
-                    first_valuation.flip_value(var);
-                }
-            }
-        }
-    }
-}
-
-impl BddSatisfyingValuations<'_> {
-    /// **(internal)** Increment the given valuation, but do not change the bits that have mask set to true.
-    /// Returns true if increment was successful, false when overflowed.
-    fn increment_masked_valuation(valuation: &mut BddValuation, mask: &BddValuation) -> bool {
-        for i in (0..valuation.0.len()).rev() {
-            if mask.0[i] {
-                // This position is fixed, don't change it!
-                continue;
-            } else {
-                // This position can be changed.
-                valuation.0[i] = !valuation.0[i];
-                if valuation.0[i] {
-                    // If it changed from 0 to 1, we are done.
-                    return true;
-                }
-            }
-        }
-        false // Valuation increment overflow.
-    }
-
-    /// **(internal)** Find next satisfying path in the Bdd and update path mask and first valuation
-    /// accordingly. If this was the last satisfying path, returns false.
-    fn next_sat_path(
-        bdd: &Bdd,
-        sat_path: &mut Vec<BddPointer>,
-        path_mask: &mut BddValuation,
-        first_valuation: &mut BddValuation,
-    ) -> bool {
-        // Pop unusable end of path until a variable that can be flipped from 0 to 1 is found.
-        while let Some(top) = sat_path.pop() {
-            if let Some(candidate) = sat_path.last() {
-                if top == bdd.high_link_of(*candidate) {
-                    // This path already follows the high link of candidate - that means we
-                    // will pop candidate and look for a completely new path.
-                } else {
-                    // Here, we can switching from low link to high link.
-                    assert_eq!(top, bdd.low_link_of(*candidate));
-                    let high = bdd.high_link_of(*candidate);
-                    if high.is_zero() {
-                        // But if high is zero, there will be no sat path there and we cannot switch,
-                        // so just pop it as well.
-                    } else {
-                        // Here, we actually have a non-empty high link that we can switch to!
-                        // But first, we have to clear path_mask and first_valuation up to the variable
-                        // of candidate (which remains to be set, just not to 0, but to 1).
-                        let var = bdd.var_of(*candidate);
-                        assert!(path_mask.value(var));
-                        assert!(!first_valuation.value(var));
-                        sat_path.push(high);
-                        first_valuation.set(var); // flip candidate from 0 to 1
-                        for i in (var.0 + 1)..bdd.num_vars() {
-                            // clear everything that comes after candidate
-                            path_mask.clear(BddVariable(i));
-                            first_valuation.clear(BddVariable(i))
-                        }
-                        // Now we are ready to finalize the fresh path.
-                        bdd.continue_sat_path(sat_path, path_mask, first_valuation);
-                        return true;
-                    }
-                }
-            }
-        }
-        // If we got here, it means there was no link on path that we could have flipped from low
-        // to high, hence this was the last path...
-        false
     }
 }
 
@@ -129,19 +23,18 @@ impl Iterator for BddSatisfyingValuations<'_> {
     type Item = BddValuation;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some((sat_path, path_mask, next_valuation)) = &mut self.continuation {
-            // Make a copy of the original valuation.
-            let result = next_valuation.clone();
-            if !BddSatisfyingValuations::increment_masked_valuation(next_valuation, path_mask) {
-                // Valuation cannot be incremented (overflow) - find next SAT path.
-                if !Self::next_sat_path(self.bdd, sat_path, path_mask, next_valuation) {
-                    // No more paths. Return last valuation and then die.
-                    self.continuation = None;
-                }
-            }
-            Some(result)
+        let next_valuation = self.valuations.next();
+        if next_valuation.is_some() {
+            next_valuation
         } else {
-            None
+            if let Some(next_path) = self.paths.next() {
+                self.valuations = ValuationsOfClauseIterator::new(next_path, self.bdd.num_vars());
+                // A new valuations iterator is never empty unless created using the `empty` constructor.
+                self.valuations.next()
+            } else {
+                // We are done.
+                None
+            }
         }
     }
 }
@@ -149,7 +42,7 @@ impl Iterator for BddSatisfyingValuations<'_> {
 #[cfg(test)]
 mod tests {
     use crate::_test_util::mk_5_variable_set;
-    use crate::{Bdd, BddValuation, BddValuationIterator};
+    use crate::{Bdd, BddValuation, ValuationsOfClauseIterator};
 
     #[test]
     fn bdd_sat_valuations_trivial() {
@@ -157,7 +50,8 @@ mod tests {
         let f = Bdd::mk_false(4);
         assert!(f.sat_valuations().next().is_none());
         let mut sat_valuations: Vec<BddValuation> = t.sat_valuations().collect();
-        let mut expected: Vec<BddValuation> = BddValuationIterator::new(4).collect();
+        let mut expected: Vec<BddValuation> =
+            ValuationsOfClauseIterator::new_unconstrained(4).collect();
         sat_valuations.sort();
         expected.sort();
 
@@ -176,7 +70,7 @@ mod tests {
         let bdd = variables.eval_expression_string("(v4 => (v1 & v2)) & (!v4 => (!v1 & v3))");
 
         let mut sat_valuations: Vec<BddValuation> = bdd.sat_valuations().collect();
-        let mut expected: Vec<BddValuation> = BddValuationIterator::new(5)
+        let mut expected: Vec<BddValuation> = ValuationsOfClauseIterator::new_unconstrained(5)
             .filter(|valuation| bdd.eval_in(valuation))
             .collect();
 

--- a/src/_impl_bdd_variable_set.rs
+++ b/src/_impl_bdd_variable_set.rs
@@ -110,11 +110,11 @@ impl BddVariableSet {
     /// a `Bdd` for the formula `x & !y & z`. An empty valuation evaluates to `true`.
     ///
     /// *Panics:* All variables in the partial valuation must belong into this set.
-    pub fn mk_conjunctive_clause(&self, valuation: &BddPartialValuation) -> Bdd {
+    pub fn mk_conjunctive_clause(&self, clause: &BddPartialValuation) -> Bdd {
         let mut result = self.mk_true();
         // It is important to iterate in this direction, otherwise we are going to mess with
         // variable ordering.
-        for (index, value) in valuation.0.iter().enumerate().rev() {
+        for (index, value) in clause.0.iter().enumerate().rev() {
             if let Some(value) = value {
                 assert!(index < self.num_vars as usize);
                 // This is safe because valuation cannot contain larger indices due to the way
@@ -144,9 +144,9 @@ impl BddVariableSet {
     /// a `Bdd` for the formula `x | !y | z`. An empty valuation evaluates to `false`.
     ///
     /// *Panics:* All variables in the valuation must belong into this set.
-    pub fn mk_disjunctive_clause(&self, valuation: &BddPartialValuation) -> Bdd {
+    pub fn mk_disjunctive_clause(&self, clause: &BddPartialValuation) -> Bdd {
         // See `mk_conjunctive_clause`, for details.
-        if valuation.is_empty() {
+        if clause.is_empty() {
             return self.mk_false();
         }
 
@@ -155,7 +155,7 @@ impl BddVariableSet {
         // zero as the root instead of one. So we use a variable which is pre-set in the
         // first iteration but will evaluate to real root in later iterations.
         let mut shadow_root = BddPointer::zero();
-        for (index, value) in valuation.0.iter().enumerate().rev() {
+        for (index, value) in clause.0.iter().enumerate().rev() {
             if let Some(value) = value {
                 assert!(index < self.num_vars as usize);
                 debug_assert!(u16::try_from(index).is_ok());

--- a/src/_impl_iterator_valuations_of_clause.rs
+++ b/src/_impl_iterator_valuations_of_clause.rs
@@ -1,0 +1,91 @@
+use crate::{BddPartialValuation, BddValuation, ValuationsOfClauseIterator};
+use std::mem::swap;
+
+impl ValuationsOfClauseIterator {
+    /// Create an empty valuation iterator.
+    pub fn empty() -> ValuationsOfClauseIterator {
+        ValuationsOfClauseIterator {
+            next_valuation: None,
+            clause: BddPartialValuation::empty(),
+        }
+    }
+
+    /// Create a new valuation iterator from a conjunctive clause and a variable count.
+    ///
+    /// The iterator will visit every valuation in the `2^num_vars` space that also satisfies
+    /// the given `clause`.
+    pub fn new(clause: BddPartialValuation, num_vars: u16) -> ValuationsOfClauseIterator {
+        let mut first_valuation = BddValuation::all_false(num_vars);
+        for (var, value) in clause.to_values() {
+            if value {
+                first_valuation.flip_value(var);
+            }
+        }
+
+        ValuationsOfClauseIterator {
+            next_valuation: Some(first_valuation),
+            clause,
+        }
+    }
+
+    /// Create a new valuation iterator which is not constrained by any clause and will
+    /// iterate over all `2^num_vars`.
+    pub fn new_unconstrained(num_vars: u16) -> ValuationsOfClauseIterator {
+        ValuationsOfClauseIterator {
+            next_valuation: Some(BddValuation::all_false(num_vars)),
+            clause: BddPartialValuation::empty(),
+        }
+    }
+}
+
+impl Iterator for ValuationsOfClauseIterator {
+    type Item = BddValuation;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(valuation) = &self.next_valuation {
+            // Compute the next valuation and then swap it with the current value.
+            // In the end, result contains self.next_valuation and next_valuation
+            // contains the result of valuation.next.
+            let mut result = valuation.next(&self.clause);
+            swap(&mut result, &mut self.next_valuation);
+            result
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BddPartialValuation, BddValuation, BddVariable, ValuationsOfClauseIterator};
+    use std::convert::TryFrom;
+
+    #[test]
+    fn valuations_of_clause_iterator_unconstrained() {
+        let singleton = ValuationsOfClauseIterator::new_unconstrained(0);
+        assert_eq!(1, singleton.count());
+        let three_vars = ValuationsOfClauseIterator::new_unconstrained(3);
+        assert_eq!(8, three_vars.count());
+    }
+
+    #[test]
+    fn valuations_of_clause_iterator_constrained() {
+        let x1 = BddVariable(0);
+        let x2 = BddVariable(1);
+        let x3 = BddVariable(2);
+        let clause = BddPartialValuation::from_values(&[(x1, true), (x2, false), (x3, true)]);
+        let singleton = ValuationsOfClauseIterator::new(clause.clone(), 3);
+        assert_eq!(1, singleton.clone().count());
+        assert_eq!(
+            BddValuation::try_from(clause).unwrap(),
+            singleton.clone().next().unwrap()
+        );
+
+        let clause = BddPartialValuation::from_values(&[(x1, true), (x3, false)]);
+        let iterator = ValuationsOfClauseIterator::new(clause.clone(), 4);
+        assert_eq!(4, iterator.clone().count());
+        iterator.for_each(|valuation| {
+            assert!(valuation.extends(&clause));
+        })
+    }
+}

--- a/src/_test_bdd/_test_bdd_logic_fuzzing.rs
+++ b/src/_test_bdd/_test_bdd_logic_fuzzing.rs
@@ -154,7 +154,7 @@ fn fuzz_test(num_vars: u16, tree_height: u8, seed: u64) {
     let op_tree = BddOpTree::new_random(tree_height, num_vars, seed);
     let eval = op_tree.eval_in(&universe);
 
-    for valuation in BddValuationIterator::new(num_vars) {
+    for valuation in ValuationsOfClauseIterator::new_unconstrained(num_vars) {
         assert_eq!(
             op_tree.eval_in_valuation(&valuation),
             eval.eval_in(&valuation),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,12 @@ mod _impl_bdd_variable_set;
 /// **(internal)** Implementation of the `BddVariableSetBuilder`.
 mod _impl_bdd_variable_set_builder;
 
+/// **(internal)** Implementation of the `ValuationOfClauseIterator`.
+mod _impl_iterator_valuations_of_clause;
+
+/// **(internal)** Implementation of the `BddPathIterator`.
+mod _impl_bdd_path_iterator;
+
 /// **(internal)** A macro module for simplifying BDD operations.
 mod _macro_bdd;
 
@@ -109,14 +115,38 @@ pub struct BddPartialValuation(Vec<Option<bool>>);
 /// Exhaustively iterates over all valuations with a certain number of variables.
 ///
 /// Be aware of the exponential time complexity of such operation!
-pub struct BddValuationIterator(Option<BddValuation>);
+///
+/// *Deprecated in favour of `ValuationsOfClauseIterator` which provides the same
+/// functionality when given an empty clause.*
+#[deprecated]
+pub struct BddValuationIterator(ValuationsOfClauseIterator);
 
 /// An iterator over all satisfying valuations of a specific BDD.
 ///
 /// Be aware of the potential exponential number of iterations!
 pub struct BddSatisfyingValuations<'a> {
     bdd: &'a Bdd,
-    continuation: Option<(Vec<BddPointer>, BddValuation, BddValuation)>,
+    paths: BddPathIterator<'a>,
+    valuations: ValuationsOfClauseIterator,
+}
+
+/// An iterator which goes through all paths in the `Bdd`, representing them as clauses using
+/// `BddPartialValuation`.
+pub struct BddPathIterator<'a> {
+    bdd: &'a Bdd,
+    // Stack keeps the last discovered path. If last path was consumed, the stack is empty.
+    stack: Vec<BddPointer>,
+}
+
+/// An iterator which goes through all valuations that satisfy a specific *conjunctive* clause.
+///
+/// Mind that the number of valuations satisfying a clause can be exponential!
+///
+/// Note that the clause can be empty, in which case this is equivalent to `BddValuationIterator`.
+#[derive(Clone)]
+pub struct ValuationsOfClauseIterator {
+    next_valuation: Option<BddValuation>,
+    clause: BddPartialValuation,
 }
 
 /// Maintains the set of variables that can appear in a `Bdd`.

--- a/src/tutorial/mod.rs
+++ b/src/tutorial/mod.rs
@@ -6,9 +6,11 @@
 //!  - [Creating a `BddVariableSet` and `BddVariable`-s](./p02_bdd_variable_set/index.html)
 //!  - [Manipulating `Bdd`s idiomatically](./p03_bdd_manipulation/index.html)
 //!  - [Serialising and visualising `Bdd`s](./p04_bdd_serialisation/index.html)
+//!  - [Working with BDD valuations and paths](./p05_bdd_valuations/index.html)
 //!
 
 pub mod p01_bdd_intro;
 pub mod p02_bdd_variable_set;
 pub mod p03_bdd_manipulation;
 pub mod p04_bdd_serialisation;
+pub mod p05_bdd_valuations;

--- a/src/tutorial/p03_bdd_manipulation.rs
+++ b/src/tutorial/p03_bdd_manipulation.rs
@@ -131,3 +131,6 @@
 //! assert_eq!(variables.mk_dnf(&formula), dnf_formula);
 //! assert_eq!(variables.mk_cnf(&formula), cnf_formula);
 //! ```
+//!
+//! To learn more about how to work with individual valuations of a `Bdd`, you can also look
+//! at the fourth chapter of this tutorial.

--- a/src/tutorial/p05_bdd_valuations.rs
+++ b/src/tutorial/p05_bdd_valuations.rs
@@ -1,0 +1,70 @@
+//! # `Bdd` paths and valuations
+//!
+//! In many cases, we need to inspect the "contents" of a `Bdd`. That is, the valuations or paths
+//! that are stored in the graph.
+//!
+//! ## Iterators
+//!
+//! Most straightforward way is to list all valuations directly. Of course, this operation
+//! can be very time consuming for a large `Bdd`. But if `Bdd.cardinality()` is sufficiently small,
+//! it is possible to enumerate all valuations of a `Bdd`:
+//!
+//! ```rust
+//! use biodivine_lib_bdd::{Bdd, ValuationsOfClauseIterator, BddVariableSet};
+//! use std::collections::HashSet;
+//! let variables = BddVariableSet::new(vec!["v1", "v2", "v3", "v4"]);
+//! let bdd = variables.eval_expression_string("(v4 => (v1 & v2)) & (!v4 => (!v1 & v3))");
+//!
+//! bdd.sat_valuations().for_each(|valuation| {
+//!     // Assuming the valuation has the right number of variables, every `Bdd` evaluates
+//!     // to true/false in a valuation.
+//!     assert!(bdd.eval_in(&valuation));
+//! });
+//!
+//! let sat = bdd.sat_valuations().collect::<HashSet<_>>();
+//!
+//! // You can also create an iterator over *every* valuation. This is effectively the same as
+//! // calling variables.mk_true().sat_valuations().
+//! let all_valuations = ValuationsOfClauseIterator::new_unconstrained(bdd.num_vars());
+//! all_valuations.for_each(|valuation| {
+//!     assert_eq!(bdd.eval_in(&valuation), sat.contains(&valuation));
+//! });
+//!
+//! // Of course, you can convert a valuation back to a `Bdd`:
+//! let first = Bdd::from(bdd.sat_valuations().next().unwrap());
+//! assert!(!first.and(&bdd).is_false());
+//! assert!(first.is_valuation());  // Tests that a `Bdd` represents exactly one valuation.
+//! ```
+//!
+//! If the number of valuations is too big, you can often still examine all *paths* of a `Bdd`
+//! (leading to `1`):
+//!
+//! ```rust
+//! use biodivine_lib_bdd::{Bdd, ValuationsOfClauseIterator, BddVariableSet};
+//! use std::collections::HashSet;
+//! let variables = BddVariableSet::new(vec!["v1", "v2", "v3", "v4"]);
+//! let bdd = variables.eval_expression_string("(v4 => (v1 & v2)) & (!v4 => (!v1 & v3))");
+//!
+//! bdd.paths().for_each(|path| {
+//!     // To convert a path back into a `Bdd`, we need to interpret it as a conjunctive clause.
+//!     let path_as_bdd = variables.mk_conjunctive_clause(&path);
+//!     assert!(!path_as_bdd.and(&bdd).is_false());
+//!     // And we can also test whether the `Bdd` is a single path.
+//!     assert!(path_as_bdd.is_clause());
+//! });
+//! ```
+//!
+//! ## Path/valuation selectors
+//!
+//! If the `Bdd` is very big, even iterating paths can be a problem. However, you can still use
+//! some of the following methods to obtain some insight into the structure of the `Bdd`:
+//!
+//!  - `Bdd.first_valuation` and `Bdd.last_valuation` will give you the (lexicographically) first
+//! and last valuation.
+//!  - Similarly, `Bdd.first_path` and `Bdd.last_path` will give you the first and last path.
+//!  - `Bdd.most_positive_valuation` and `Bdd.most_negative_valuation` return the valuations
+//! with highest amount of positive/negative literals.
+//!  - `Bdd.most_fixed_path` and `Bdd.most_free_path` wil give you satisfying paths with
+//! greatest and least amount of fixed variables respectively.
+//!
+//!

--- a/src/tutorial/p05_bdd_valuations.rs
+++ b/src/tutorial/p05_bdd_valuations.rs
@@ -45,13 +45,21 @@
 //! let variables = BddVariableSet::new(vec!["v1", "v2", "v3", "v4"]);
 //! let bdd = variables.eval_expression_string("(v4 => (v1 & v2)) & (!v4 => (!v1 & v3))");
 //!
+//! let mut total = 0;
 //! bdd.paths().for_each(|path| {
 //!     // To convert a path back into a `Bdd`, we need to interpret it as a conjunctive clause.
 //!     let path_as_bdd = variables.mk_conjunctive_clause(&path);
 //!     assert!(!path_as_bdd.and(&bdd).is_false());
 //!     // And we can also test whether the `Bdd` is a single path.
 //!     assert!(path_as_bdd.is_clause());
+//!
+//!     // Keep in mind that you can still iterate over valuations that match a specific path:
+//!     for valuation in ValuationsOfClauseIterator::new(path, bdd.num_vars()) {
+//!         total += 1;
+//!     }
 //! });
+//!
+//! assert_eq!(total, bdd.sat_valuations().count());
 //! ```
 //!
 //! ## Path/valuation selectors


### PR DESCRIPTION
This pull request resolves `BddValuation` and `BddParitalValuation` API deficiencies described in #22. Specifically, it includes following improvements:

 - Implements a check for whether a `Bdd` is a single clause/valuation.
 - Completely redesigned path/valuation iterators. Now it is possible to iterate just paths, or valuations of a single path.
 - Valuation introspection utilities: first/last path/valuation, most positive/negative valuation, most free/fixed path.
 - A tutorial module which explains most of this.