### PR TITLE
Random picking of clauses/valuations.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 fxhash = "0.2.1"
-
-[dev-dependencies]
 rand = "0.7"
 
 # Enable rich docs for some online docs autogen services.

--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -51,7 +51,7 @@ impl Bdd {
 
     /// Return the lexicographically fist path in this `Bdd`, represented as
     /// a *conjunctive* clause.
-    pub fn first_path(&self) -> Option<BddPartialValuation> {
+    pub fn first_clause(&self) -> Option<BddPartialValuation> {
         if self.is_false() {
             return None;
         }
@@ -73,7 +73,7 @@ impl Bdd {
 
     /// Return the lexicographically last path in this `Bdd`, represented as
     /// a *conjunctive* clause.
-    pub fn last_path(&self) -> Option<BddPartialValuation> {
+    pub fn last_clause(&self) -> Option<BddPartialValuation> {
         if self.is_false() {
             return None;
         }
@@ -208,7 +208,7 @@ impl Bdd {
     /// Compute the path in this `Bdd` that has the highest amount of fixed variables.
     ///
     /// If there are multiple such paths, try to order them lexicographically.
-    pub fn most_fixed_path(&self) -> Option<BddPartialValuation> {
+    pub fn most_fixed_clause(&self) -> Option<BddPartialValuation> {
         if self.is_false() {
             return None;
         }
@@ -254,7 +254,7 @@ impl Bdd {
     /// Compute the path in this `Bdd` that has the highest amount of free variables.
     ///
     /// If there are multiple such paths, try to order them lexicographically.
-    pub fn most_free_path(&self) -> Option<BddPartialValuation> {
+    pub fn most_free_clause(&self) -> Option<BddPartialValuation> {
         if self.is_false() {
             return None;
         }
@@ -392,11 +392,13 @@ mod tests {
         let last_valuation = BddValuation(vec![true, true, true, false, true]);
 
         assert_eq!(Some(first_valuation), bdd.first_valuation());
+        assert_eq!(None, vars.mk_false().first_valuation());
         assert_eq!(Some(last_valuation), bdd.last_valuation());
+        assert_eq!(None, vars.mk_false().last_valuation());
     }
 
     #[test]
-    fn first_last_path() {
+    fn first_last_clause() {
         let vars = BddVariableSet::new_anonymous(5);
         let v = vars.variables();
 
@@ -405,22 +407,24 @@ mod tests {
         let c3 = BddPartialValuation::from_values(&[(v[2], false), (v[4], true)]);
         let bdd = vars.mk_dnf(&[c1.clone(), c2.clone(), c3.clone()]);
 
-        let first_path = BddPartialValuation::from_values(&[
+        let first_clause = BddPartialValuation::from_values(&[
             (v[0], false),
             (v[1], false),
             (v[2], false),
             (v[4], true),
         ]);
 
-        let last_path = BddPartialValuation::from_values(&[
+        let last_clause = BddPartialValuation::from_values(&[
             (v[0], true),
             (v[1], true),
             (v[2], true),
             (v[3], false),
         ]);
 
-        assert_eq!(Some(first_path), bdd.first_path());
-        assert_eq!(Some(last_path), bdd.last_path());
+        assert_eq!(Some(first_clause), bdd.first_clause());
+        assert_eq!(None, vars.mk_false().first_clause());
+        assert_eq!(Some(last_clause), bdd.last_clause());
+        assert_eq!(None, vars.mk_false().last_clause());
     }
 
     #[test]
@@ -437,11 +441,13 @@ mod tests {
         let most_negative_valuation = BddValuation(vec![false, false, false, false, true]);
 
         assert_eq!(Some(most_positive_valuation), bdd.most_positive_valuation());
+        assert_eq!(None, vars.mk_false().most_positive_valuation());
         assert_eq!(Some(most_negative_valuation), bdd.most_negative_valuation());
+        assert_eq!(None, vars.mk_false().most_negative_valuation());
     }
 
     #[test]
-    fn most_fixed_free_path() {
+    fn most_fixed_free_clause() {
         let vars = BddVariableSet::new_anonymous(5);
         let v = vars.variables();
 
@@ -452,17 +458,19 @@ mod tests {
 
         //println!("{}", bdd.to_dot_string(&vars, true));
 
-        let fixed_path = BddPartialValuation::from_values(&[
+        let fixed_clause = BddPartialValuation::from_values(&[
             (v[0], false),
             (v[1], true),
             (v[2], false),
             (v[3], true),
             (v[4], true),
         ]);
-        let free_path = BddPartialValuation::from_values(&[(v[0], true), (v[1], false)]);
+        let free_clause = BddPartialValuation::from_values(&[(v[0], true), (v[1], false)]);
 
-        assert_eq!(Some(fixed_path), bdd.most_fixed_path());
-        assert_eq!(Some(free_path), bdd.most_free_path());
+        assert_eq!(Some(fixed_clause), bdd.most_fixed_clause());
+        assert_eq!(None, vars.mk_false().most_fixed_clause());
+        assert_eq!(Some(free_clause), bdd.most_free_clause());
+        assert_eq!(None, vars.mk_false().most_free_clause());
     }
 
     #[test]

--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -1,4 +1,5 @@
-use crate::{Bdd, BddPartialValuation, BddValuation};
+use crate::{Bdd, BddPartialValuation, BddValuation, BddVariable};
+use rand::Rng;
 
 /// Utilities for extracting interesting valuations and paths from a `Bdd`.
 impl Bdd {
@@ -299,11 +300,83 @@ impl Bdd {
 
         Some(valuation)
     }
+
+    /// Pick a random valuation that satisfies this `Bdd`, using a provided random number
+    /// generator.
+    ///
+    /// Note that the random distribution with which the valuations are picked depends
+    /// on the structure of the `Bdd` and is not necessarily uniform.
+    pub fn random_valuation<R: Rng>(&self, rng: &mut R) -> Option<BddValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut valuation = BddValuation::all_false(self.num_vars());
+        let mut node = self.root_pointer();
+        for i_var in 0..self.num_vars() {
+            let var = BddVariable(i_var);
+            if self.var_of(node) != var {
+                // Just pick random.
+                valuation.set_value(var, rng.gen_bool(0.5));
+            } else {
+                let child = if self.low_link_of(node).is_zero() {
+                    true
+                } else if self.high_link_of(node).is_zero() {
+                    false
+                } else {
+                    rng.gen_bool(0.5)
+                };
+
+                valuation.set_value(var, child);
+                node = if child {
+                    self.high_link_of(node)
+                } else {
+                    self.low_link_of(node)
+                }
+            }
+        }
+
+        Some(valuation)
+    }
+
+    /// Pick a random path that appears in this `Bdd`, using a provided random number
+    /// generator.
+    ///
+    /// Note that the distribution with which the path is picked depends on the structure
+    /// of the `Bdd` and is not necessarily uniform.
+    pub fn random_clause<R: Rng>(&self, rng: &mut R) -> Option<BddPartialValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut path = BddPartialValuation::empty();
+        let mut node = self.root_pointer();
+        while !node.is_one() {
+            let child = if self.low_link_of(node).is_zero() {
+                true
+            } else if self.high_link_of(node).is_zero() {
+                false
+            } else {
+                rng.gen_bool(0.5)
+            };
+
+            path.set_value(self.var_of(node), child);
+            node = if child {
+                self.high_link_of(node)
+            } else {
+                self.low_link_of(node)
+            }
+        }
+
+        Some(path)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{BddPartialValuation, BddValuation, BddVariableSet};
+    use rand::prelude::StdRng;
+    use rand::SeedableRng;
 
     #[test]
     fn first_last_valuation() {
@@ -390,5 +463,44 @@ mod tests {
 
         assert_eq!(Some(fixed_path), bdd.most_fixed_path());
         assert_eq!(Some(free_path), bdd.most_free_path());
+    }
+
+    #[test]
+    fn random_valuation() {
+        let vars = BddVariableSet::new_anonymous(5);
+        let v = vars.variables();
+
+        let c1 = BddPartialValuation::from_values(&[(v[0], true), (v[1], false)]);
+        let c2 = BddPartialValuation::from_values(&[(v[1], true), (v[3], false)]);
+        let c3 = BddPartialValuation::from_values(&[(v[2], false), (v[4], true)]);
+        let bdd = vars.mk_dnf(&[c1.clone(), c2.clone(), c3.clone()]);
+
+        let mut random = StdRng::seed_from_u64(1234567890);
+        for _ in 0..100 {
+            let valuation = bdd.random_valuation(&mut random).unwrap();
+            assert!(bdd.eval_in(&valuation));
+        }
+
+        assert_eq!(None, vars.mk_false().random_valuation(&mut random));
+    }
+
+    #[test]
+    fn random_clause() {
+        let vars = BddVariableSet::new_anonymous(5);
+        let v = vars.variables();
+
+        let c1 = BddPartialValuation::from_values(&[(v[0], true), (v[1], false)]);
+        let c2 = BddPartialValuation::from_values(&[(v[1], true), (v[3], false)]);
+        let c3 = BddPartialValuation::from_values(&[(v[2], false), (v[4], true)]);
+        let bdd = vars.mk_dnf(&[c1.clone(), c2.clone(), c3.clone()]);
+
+        let mut random = StdRng::seed_from_u64(1234567890);
+        for _ in 0..100 {
+            let clause = bdd.random_clause(&mut random).unwrap();
+            let clause_bdd = vars.mk_conjunctive_clause(&clause);
+            assert_eq!(clause_bdd.and(&bdd), clause_bdd);
+        }
+
+        assert_eq!(None, vars.mk_false().random_clause(&mut random));
     }
 }

--- a/src/_impl_bdd_satisfying_valuations.rs
+++ b/src/_impl_bdd_satisfying_valuations.rs
@@ -27,7 +27,7 @@ impl Bdd {
     ///
     /// The whole formula represented by a `Bdd` can be then seen as a disjunction of these
     /// clauses/paths.
-    pub fn paths(&self) -> BddPathIterator {
+    pub fn sat_clauses(&self) -> BddPathIterator {
         BddPathIterator::new(self)
     }
 }

--- a/src/tutorial/mod.rs
+++ b/src/tutorial/mod.rs
@@ -6,7 +6,7 @@
 //!  - [Creating a `BddVariableSet` and `BddVariable`-s](./p02_bdd_variable_set/index.html)
 //!  - [Manipulating `Bdd`s idiomatically](./p03_bdd_manipulation/index.html)
 //!  - [Serialising and visualising `Bdd`s](./p04_bdd_serialisation/index.html)
-//!  - [Working with BDD valuations and paths](./p05_bdd_valuations/index.html)
+//!  - [Working with BDD valuations and clauses](./p05_bdd_valuations/index.html)
 //!
 
 pub mod p01_bdd_intro;

--- a/src/tutorial/p05_bdd_valuations.rs
+++ b/src/tutorial/p05_bdd_valuations.rs
@@ -1,6 +1,6 @@
-//! # `Bdd` paths and valuations
+//! # `Bdd` clauses and valuations
 //!
-//! In many cases, we need to inspect the "contents" of a `Bdd`. That is, the valuations or paths
+//! In many cases, we need to inspect the "contents" of a `Bdd`. That is, the valuations or clauses
 //! that are stored in the graph.
 //!
 //! ## Iterators
@@ -36,8 +36,8 @@
 //! assert!(first.is_valuation());  // Tests that a `Bdd` represents exactly one valuation.
 //! ```
 //!
-//! If the number of valuations is too big, you can often still examine all *paths* of a `Bdd`
-//! (leading to `1`):
+//! If the number of valuations is too big, you can often still examine all *clauses* of a `Bdd`
+//! (i.e. paths leading to `1`):
 //!
 //! ```rust
 //! use biodivine_lib_bdd::{Bdd, ValuationsOfClauseIterator, BddVariableSet};
@@ -46,15 +46,15 @@
 //! let bdd = variables.eval_expression_string("(v4 => (v1 & v2)) & (!v4 => (!v1 & v3))");
 //!
 //! let mut total = 0;
-//! bdd.paths().for_each(|path| {
+//! bdd.sat_clauses().for_each(|clause| {
 //!     // To convert a path back into a `Bdd`, we need to interpret it as a conjunctive clause.
-//!     let path_as_bdd = variables.mk_conjunctive_clause(&path);
-//!     assert!(!path_as_bdd.and(&bdd).is_false());
+//!     let clause_bdd = variables.mk_conjunctive_clause(&clause);
+//!     assert!(!clause_bdd.and(&bdd).is_false());
 //!     // And we can also test whether the `Bdd` is a single path.
-//!     assert!(path_as_bdd.is_clause());
+//!     assert!(clause_bdd.is_clause());
 //!
 //!     // Keep in mind that you can still iterate over valuations that match a specific path:
-//!     for valuation in ValuationsOfClauseIterator::new(path, bdd.num_vars()) {
+//!     for valuation in ValuationsOfClauseIterator::new(clause, bdd.num_vars()) {
 //!         total += 1;
 //!     }
 //! });
@@ -69,10 +69,11 @@
 //!
 //!  - `Bdd.first_valuation` and `Bdd.last_valuation` will give you the (lexicographically) first
 //! and last valuation.
-//!  - Similarly, `Bdd.first_path` and `Bdd.last_path` will give you the first and last path.
+//!  - Similarly, `Bdd.first_clause` and `Bdd.last_clause` will give you the first and last path
+//! satisfying path.
 //!  - `Bdd.most_positive_valuation` and `Bdd.most_negative_valuation` return the valuations
 //! with highest amount of positive/negative literals.
-//!  - `Bdd.most_fixed_path` and `Bdd.most_free_path` wil give you satisfying paths with
+//!  - `Bdd.most_fixed_clause` and `Bdd.most_free_clause` wil give you satisfying paths with
 //! greatest and least amount of fixed variables respectively.
 //!
 //!


### PR DESCRIPTION
This PR resolves issue #23. It adds new methods that allow to pick valuations and clauses based on values provided by a random number generator. Sadly, the distribution used by these methods is not uniform, but it should be sufficient for now (A uniform approach is possible, but requires pre-computation of cardinality for each node).

Additionally, `path` was renamed to `clause` to better mimic logical terminology.