### PR TITLE
Support `Conditional` ternary operator

### DIFF
--- a/src/boolean_expression/_impl_boolean_expression.rs
+++ b/src/boolean_expression/_impl_boolean_expression.rs
@@ -24,6 +24,7 @@ impl Display for BooleanExpression {
             Xor(l, r) => write!(f, "({} ^ {})", l, r),
             Imp(l, r) => write!(f, "({} => {})", l, r),
             Iff(l, r) => write!(f, "({} <=> {})", l, r),
+            Cond(cond, then_expr, else_expr) => write!(f, "({} ? {} : {})", cond, then_expr,else_expr),
         }
     }
 }
@@ -65,6 +66,12 @@ impl BddVariableSet {
                 let left = self.safe_eval_expression(l)?;
                 let right = self.safe_eval_expression(r)?;
                 Some(left.iff(&right))
+            }
+            Cond(cond, then_expr, else_expr) => {
+                let cond = self.safe_eval_expression(cond)?;
+                let then_expr = self.safe_eval_expression(then_expr)?;
+                let else_expr = self.safe_eval_expression(else_expr)?;
+                Some(Bdd::if_then_else(&cond,&then_expr,&else_expr))
             }
         }
     }

--- a/src/boolean_expression/_impl_boolean_expression.rs
+++ b/src/boolean_expression/_impl_boolean_expression.rs
@@ -24,7 +24,9 @@ impl Display for BooleanExpression {
             Xor(l, r) => write!(f, "({} ^ {})", l, r),
             Imp(l, r) => write!(f, "({} => {})", l, r),
             Iff(l, r) => write!(f, "({} <=> {})", l, r),
-            Cond(cond, then_expr, else_expr) => write!(f, "({} ? {} : {})", cond, then_expr,else_expr),
+            Cond(cond, then_expr, else_expr) => {
+                write!(f, "({} ? {} : {})", cond, then_expr, else_expr)
+            }
         }
     }
 }
@@ -71,7 +73,7 @@ impl BddVariableSet {
                 let cond = self.safe_eval_expression(cond)?;
                 let then_expr = self.safe_eval_expression(then_expr)?;
                 let else_expr = self.safe_eval_expression(else_expr)?;
-                Some(Bdd::if_then_else(&cond,&then_expr,&else_expr))
+                Some(Bdd::if_then_else(&cond, &then_expr, &else_expr))
             }
         }
     }

--- a/src/boolean_expression/_impl_parser.rs
+++ b/src/boolean_expression/_impl_parser.rs
@@ -132,36 +132,37 @@ fn iff(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
 fn imp(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     let imp_token = index_of_first(data, ExprToken::Imp);
     Ok(if let Some(imp_token) = imp_token {
-        Box::new(Imp(cond(&data[..imp_token])?, imp(&data[(imp_token + 1)..])?))
+        Box::new(Imp(
+            cond(&data[..imp_token])?,
+            imp(&data[(imp_token + 1)..])?,
+        ))
     } else {
         cond(data)?
     })
 }
 
 /// **(internal)** Recursive parsing step 3: extract `cond ? then_expr : else_expr` operators.
-/// 
+///
 /// + Vaild: `(cond1 ? then_expr1 : else_expr1) + (cond2 ? then_expr2 : else_expr2)`
-/// 
+///
 /// + Vaild: `(cond1 ? then_expr1 : else_expr1) + cond2 ? then_expr2 : else_expr2`
-/// 
+///
 /// + Vaild: `cond1 ? then_expr1 : else_expr1 + (cond2 ? then_expr2 : else_expr2)`
-/// 
+///
 /// + Invalid: `cond1 ? then_expr1 : cond2 ? then_expr2 : else_expr2`
 fn cond(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     let question_token = index_of_first(data, ExprToken::QuestionMark);
     let colon_token = index_of_first(data, ExprToken::Colon);
-        match (question_token,colon_token){
-            (None, None) => or(data),
-            (Some(question_token), Some(colon_token)) => Ok(Box::new(Cond(
-                or(&data[..question_token])?,or(&data[(question_token+1)..colon_token])?,or(&data[(colon_token + 1)..])?
-            ))),
-            (None, Some(_)) => Err(format!(
-                "Expected `?` but only found `:`."
-            )),
-            (Some(_), None) => Err(format!(
-                "Expected `:` but only found `?`."
-            )),
-        }
+    match (question_token, colon_token) {
+        (None, None) => or(data),
+        (Some(question_token), Some(colon_token)) => Ok(Box::new(Cond(
+            or(&data[..question_token])?,
+            or(&data[(question_token + 1)..colon_token])?,
+            or(&data[(colon_token + 1)..])?,
+        ))),
+        (None, Some(_)) => Err(format!("Expected `?` but only found `:`.")),
+        (Some(_), None) => Err(format!("Expected `:` but only found `?`.")),
+    }
 }
 
 /// **(internal)** Recursive parsing step 4: extract `|` operators.
@@ -237,16 +238,16 @@ mod tests {
     #[test]
     fn parse_boolean_formula_basic() {
         let inputs = vec![
-            "v_1+{14}",      // just a variable name with fancy symbols
-            "!v_1",          // negation
-            "true",          // true
-            "false",         // false
-            "(v_1 & v_2)",   // and
-            "(cond ? then_expr : else_expr)",   // cond
-            "(v_1 | v_2)",   // or
-            "(v_1 ^ v_2)",   // xor
-            "(v_1 => v_2)",  // imp
-            "(v_1 <=> v_2)", // iff
+            "v_1+{14}",                       // just a variable name with fancy symbols
+            "!v_1",                           // negation
+            "true",                           // true
+            "false",                          // false
+            "(v_1 & v_2)",                    // and
+            "(cond ? then_expr : else_expr)", // cond
+            "(v_1 | v_2)",                    // or
+            "(v_1 ^ v_2)",                    // xor
+            "(v_1 => v_2)",                   // imp
+            "(v_1 <=> v_2)",                  // iff
         ];
         for input in inputs {
             assert_eq!(
@@ -291,11 +292,17 @@ mod tests {
         );
         assert_eq!(
             "((a ? b : c) ? d : e)",
-            format!("{}", parse_boolean_expression("(a ? b : c) ? d : e").unwrap())
+            format!(
+                "{}",
+                parse_boolean_expression("(a ? b : c) ? d : e").unwrap()
+            )
         );
         assert_eq!(
             "(a ? b : (c ? d : e))",
-            format!("{}", parse_boolean_expression("a ? b : (c ? d : e)").unwrap())
+            format!(
+                "{}",
+                parse_boolean_expression("a ? b : (c ? d : e)").unwrap()
+            )
         );
     }
 

--- a/src/boolean_expression/_impl_parser.rs
+++ b/src/boolean_expression/_impl_parser.rs
@@ -156,12 +156,10 @@ fn cond(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
                 or(&data[..question_token])?,or(&data[(question_token+1)..colon_token])?,or(&data[(colon_token + 1)..])?
             ))),
             (None, Some(_)) => Err(format!(
-                "Expected variable name or (...), but found {:?}.",
-                data
+                "Expected `?` but only found `:`."
             )),
             (Some(_), None) => Err(format!(
-                "Expected variable name or (...), but found {:?}.",
-                data
+                "Expected `:` but only found `?`."
             )),
         }
 }

--- a/src/boolean_expression/_impl_parser.rs
+++ b/src/boolean_expression/_impl_parser.rs
@@ -21,6 +21,8 @@ enum ExprToken {
     Xor,                    // '^'
     Imp,                    // '=>'
     Iff,                    // '<=>'
+    Colon,                  // ':'
+    QuestionMark,           // '?'
     Id(String),             // 'variable'
     Tokens(Vec<ExprToken>), // A block of tokens inside parentheses
 }
@@ -47,6 +49,8 @@ fn tokenize_group(data: &mut Peekable<Chars>, top_level: bool) -> Result<Vec<Exp
             '&' => output.push(ExprToken::And),
             '|' => output.push(ExprToken::Or),
             '^' => output.push(ExprToken::Xor),
+            ':' => output.push(ExprToken::Colon),
+            '?' => output.push(ExprToken::QuestionMark),
             '=' => {
                 if Some('>') == data.next() {
                     output.push(ExprToken::Imp);
@@ -128,13 +132,41 @@ fn iff(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
 fn imp(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     let imp_token = index_of_first(data, ExprToken::Imp);
     Ok(if let Some(imp_token) = imp_token {
-        Box::new(Imp(or(&data[..imp_token])?, imp(&data[(imp_token + 1)..])?))
+        Box::new(Imp(cond(&data[..imp_token])?, imp(&data[(imp_token + 1)..])?))
     } else {
-        or(data)?
+        cond(data)?
     })
 }
 
-/// **(internal)** Recursive parsing step 3: extract `|` operators.
+/// **(internal)** Recursive parsing step 3: extract `cond ? then_expr : else_expr` operators.
+/// 
+/// + Vaild: `(cond1 ? then_expr1 : else_expr1) + (cond2 ? then_expr2 : else_expr2)`
+/// 
+/// + Vaild: `(cond1 ? then_expr1 : else_expr1) + cond2 ? then_expr2 : else_expr2`
+/// 
+/// + Vaild: `cond1 ? then_expr1 : else_expr1 + (cond2 ? then_expr2 : else_expr2)`
+/// 
+/// + Invalid: `cond1 ? then_expr1 : cond2 ? then_expr2 : else_expr2`
+fn cond(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
+    let question_token = index_of_first(data, ExprToken::QuestionMark);
+    let colon_token = index_of_first(data, ExprToken::Colon);
+        match (question_token,colon_token){
+            (None, None) => or(data),
+            (Some(question_token), Some(colon_token)) => Ok(Box::new(Cond(
+                or(&data[..question_token])?,or(&data[(question_token+1)..colon_token])?,or(&data[(colon_token + 1)..])?
+            ))),
+            (None, Some(_)) => Err(format!(
+                "Expected variable name or (...), but found {:?}.",
+                data
+            )),
+            (Some(_), None) => Err(format!(
+                "Expected variable name or (...), but found {:?}.",
+                data
+            )),
+        }
+}
+
+/// **(internal)** Recursive parsing step 4: extract `|` operators.
 fn or(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     let or_token = index_of_first(data, ExprToken::Or);
     Ok(if let Some(or_token) = or_token {
@@ -144,7 +176,7 @@ fn or(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     })
 }
 
-/// **(internal)** Recursive parsing step 4: extract `&` operators.
+/// **(internal)** Recursive parsing step 5: extract `&` operators.
 fn and(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     let and_token = index_of_first(data, ExprToken::And);
     Ok(if let Some(and_token) = and_token {
@@ -157,7 +189,7 @@ fn and(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     })
 }
 
-/// **(internal)** Recursive parsing step 5: extract `^` operators.
+/// **(internal)** Recursive parsing step 6: extract `^` operators.
 fn xor(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     let xor_token = index_of_first(data, ExprToken::Xor);
     Ok(if let Some(xor_token) = xor_token {
@@ -170,7 +202,7 @@ fn xor(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     })
 }
 
-/// **(internal)** Recursive parsing step 6: extract terminals and negations.
+/// **(internal)** Recursive parsing step 7: extract terminals and negations.
 fn terminal(data: &[ExprToken]) -> Result<Box<BooleanExpression>, String> {
     if data.is_empty() {
         Err("Expected formula, found nothing :(".to_string())
@@ -212,6 +244,7 @@ mod tests {
             "true",          // true
             "false",         // false
             "(v_1 & v_2)",   // and
+            "(cond ? then_expr : else_expr)",   // cond
             "(v_1 | v_2)",   // or
             "(v_1 ^ v_2)",   // xor
             "(v_1 => v_2)",  // imp
@@ -257,6 +290,14 @@ mod tests {
         assert_eq!(
             "(a <=> (b <=> c))",
             format!("{}", parse_boolean_expression("a <=> b <=> c").unwrap())
+        );
+        assert_eq!(
+            "((a ? b : c) ? d : e)",
+            format!("{}", parse_boolean_expression("(a ? b : c) ? d : e").unwrap())
+        );
+        assert_eq!(
+            "(a ? b : (c ? d : e))",
+            format!("{}", parse_boolean_expression("a ? b : (c ? d : e)").unwrap())
         );
     }
 
@@ -317,6 +358,12 @@ mod tests {
     #[should_panic]
     fn parse_boolean_formula_invalid_parentheses_4() {
         parse_boolean_expression("a & (b))").unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn parse_boolean_formula_invalid_parentheses_5() {
+        parse_boolean_expression("a ? b : c ? d : e").unwrap();
     }
 
     #[test]

--- a/src/boolean_expression/mod.rs
+++ b/src/boolean_expression/mod.rs
@@ -27,5 +27,9 @@ pub enum BooleanExpression {
     Imp(Box<BooleanExpression>, Box<BooleanExpression>),
     Iff(Box<BooleanExpression>, Box<BooleanExpression>),
     /// cond ? then_expr : else_expr
-    Cond(Box<BooleanExpression>, Box<BooleanExpression>, Box<BooleanExpression>),
+    Cond(
+        Box<BooleanExpression>,
+        Box<BooleanExpression>,
+        Box<BooleanExpression>,
+    ),
 }

--- a/src/boolean_expression/mod.rs
+++ b/src/boolean_expression/mod.rs
@@ -26,4 +26,6 @@ pub enum BooleanExpression {
     Xor(Box<BooleanExpression>, Box<BooleanExpression>),
     Imp(Box<BooleanExpression>, Box<BooleanExpression>),
     Iff(Box<BooleanExpression>, Box<BooleanExpression>),
+    /// cond ? then_expr : else_expr
+    Cond(Box<BooleanExpression>, Box<BooleanExpression>, Box<BooleanExpression>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ mod _test_util;
 
 /// **(internal)** Characters that cannot appear in the variable name
 /// (based on possible tokens in a boolean expression).
-const NOT_IN_VAR_NAME: [char; 9] = ['!', '&', '|', '^', '=', '<', '>', '(', ')'];
+const NOT_IN_VAR_NAME: [char; 11] = ['!', '&', '|', '^', '=', '<', '>', '(', ')', '?', ':'];
 
 /// An array-based encoding of the binary decision diagram implementing basic logical operations.
 ///


### PR DESCRIPTION
As https://github.com/sybila/biodivine-lib-bdd/issues/52, this PR supports `Conditional` ternary operator. 
Those features have been implemented:

+ `BooleanExpression`: Add field `Cond(Box<BooleanExpression>, Box<BooleanExpression>, Box<BooleanExpression>)`. And update `Display` for `BooleanExpression`.
+ `parser`: Implement parser for `Cond`, with priority: `imp` < `cond` < `or`.
+ `safe_eval_expression`: Implement `Cond`'s `BDD` with exsited function [`fn if_then_else(a: &Bdd, b: &Bdd, c: &Bdd) -> Bdd`](https://github.com/sybila/biodivine-lib-bdd/blob/v0.5.11/src/_impl_bdd/_impl_boolean_ops.rs#L68)

There is one potential todo validation:
+ Validation on `BDD` equivalence of `A ? B : C` and `(A & B) | (!A & C)`