### PR TITLE
support `serde` serialize/deserialize for `BooleanExpression` & `Bdd`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 fxhash = "0.2.1"
 rand = "0.8.5"
 num-bigint = "0.4.4"
-serde = { version = "1.0", optional = true, default-features = false }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Enable rich docs for some online docs autogen services.
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,12 @@ maintenance = { status = "actively-developed" }
 fxhash = "0.2.1"
 rand = "0.8.5"
 num-bigint = "0.4.4"
+serde = { version = "1.0", optional = true, default-features = false }
 
 # Enable rich docs for some online docs autogen services.
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", "./res/docs-head.html"]
+
+[features]
+default = []
+serde   = ["dep:serde"]

--- a/src/boolean_expression/mod.rs
+++ b/src/boolean_expression/mod.rs
@@ -16,6 +16,7 @@ mod _impl_boolean_expression;
 mod _impl_parser;
 
 /// Recursive type for boolean expression tree.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BooleanExpression {
     Const(bool),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,7 @@ pub struct BddPointer(u32);
 /// `BddVariableSet`. This is consistent with the fact that we first condition on smallest
 /// variable ids. It can be also used for consistency checks inside the library.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BddNode {
     pub var: BddVariable,
     pub low_link: BddPointer,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,10 +109,12 @@ const NOT_IN_VAR_NAME: [char; 11] = ['!', '&', '|', '^', '=', '<', '>', '(', ')'
 ///
 /// To create `Bdd`s for atomic formulas, use a `BddVariableSet`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Bdd(Vec<BddNode>);
 
 /// Identifies one of the variables that can appear as a decision condition in the `Bdd`.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BddVariable(u16);
 
 /// Exactly describes one assignment of boolean values to variables of a `Bdd`.
@@ -209,6 +211,7 @@ pub struct BddVariableSetBuilder {
 /// represented as `u32` instead of `usize`, because `usize` can be 64-bits and pointers
 /// represent most of the memory consumed by our BDDs.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BddPointer(u32);
 
 /// **(internal)** Representation of individual vertices of the `Bdd` directed acyclic graph.


### PR DESCRIPTION
This pull request mainly modifies two parts:
+ Add serde dependency, controlled by serde feature. Referred to https://github.com/reem/rust-ordered-float/blob/master/Cargo.toml#L19
+ Using serde's derive to conditionally implement `Serialize` & `Deserialize` for `BooleanExpression` & `Bdd`. Referred to https://stackoverflow.com/questions/42551113/is-it-possible-to-conditionally-enable-an-attribute-like-derive

Then we can use follow setting to turn on `serde` serialize/deserialize.
``` toml
biodivine-lib-bdd = {version="0.5" , features = ["serde"]}
```