### PR TITLE
Introduce `Debug` for `BddVariableSet`

### DIFF
--- a/src/_impl_bdd/_impl_export_dot.rs
+++ b/src/_impl_bdd/_impl_export_dot.rs
@@ -9,9 +9,9 @@ impl Bdd {
     ///
     /// If `zero_pruned` is true, edges leading to `zero` are not shown. This can greatly
     /// simplify the graph without losing information.
-    pub fn write_as_dot_string(
+    pub fn write_as_dot_string<W: Write>(
         &self,
-        output: &mut dyn Write,
+        output: &mut W,
         variables: &BddVariableSet,
         zero_pruned: bool,
     ) -> Result<(), std::io::Error> {
@@ -33,8 +33,8 @@ impl Bdd {
 /// custom names for individual variables. If `pruned` is true, the output will only
 /// contain edges leading to the `1` terminal node (this is often much easier to read
 /// than the full graph while preserving all the information).
-fn write_bdd_as_dot(
-    output: &mut dyn Write,
+fn write_bdd_as_dot<W: Write>(
+    output: &mut W,
     bdd: &Bdd,
     var_names: &[String],
     zero_pruned: bool,

--- a/src/_impl_bdd/_impl_serialisation.rs
+++ b/src/_impl_bdd/_impl_serialisation.rs
@@ -6,7 +6,7 @@ use std::io::{ErrorKind, Read, Write};
 /// Serialisation and deserialization methods for `Bdd`s.
 impl Bdd {
     /// Write this `Bdd` into the given `output` writer using a simple string format.
-    pub fn write_as_string(&self, output: &mut dyn Write) -> Result<(), io::Error> {
+    pub fn write_as_string<W: Write>(&self, output: &mut W) -> Result<(), io::Error> {
         write!(output, "|")?;
         for node in self.nodes() {
             write!(output, "{},{},{}|", node.var, node.low_link, node.high_link)?;
@@ -15,7 +15,7 @@ impl Bdd {
     }
 
     /// Read a `Bdd` from the given `input` reader, assuming a simple string format.
-    pub fn read_as_string(input: &mut dyn Read) -> Result<Bdd, String> {
+    pub fn read_as_string<R: Read>(input: &mut R) -> Result<Bdd, String> {
         let mut data = String::new();
         lift_err(input.read_to_string(&mut data))?;
         data.retain(|c| !c.is_whitespace()); // Ignore whitespace when parsing.
@@ -33,7 +33,7 @@ impl Bdd {
     }
 
     /// Write this `Bdd` into the given `output` writer using a simple little-endian binary encoding.
-    pub fn write_as_bytes(&self, output: &mut dyn Write) -> Result<(), io::Error> {
+    pub fn write_as_bytes<W: Write>(&self, output: &mut W) -> Result<(), io::Error> {
         for node in self.nodes() {
             output.write_all(&node.var.to_le_bytes())?;
             output.write_all(&node.low_link.to_le_bytes())?;
@@ -43,7 +43,7 @@ impl Bdd {
     }
 
     /// Read a `Bdd` from a given `input` reader using a simple little-endian binary encoding.
-    pub fn read_as_bytes(input: &mut dyn Read) -> Result<Bdd, io::Error> {
+    pub fn read_as_bytes<R: Read>(input: &mut R) -> Result<Bdd, io::Error> {
         let mut result = Vec::new();
         let mut buf = [0u8; 10];
         loop {

--- a/src/_impl_bdd/_impl_util.rs
+++ b/src/_impl_bdd/_impl_util.rs
@@ -175,7 +175,7 @@ impl Bdd {
             }
         }
         let last_var = self.0.last().unwrap().var.0;
-        cache.last().cloned().flatten().unwrap() * (one << last_var)
+        cache.pop().flatten().unwrap() * (one << last_var)
     }
 
     /// Approximately computes the number of valuations satisfying the formula given
@@ -261,7 +261,7 @@ impl Bdd {
                 }
             }
         }
-        cache.last().cloned().flatten().unwrap()
+        cache.pop().flatten().unwrap()
     }
 
     /// If the `Bdd` is satisfiable, return some `BddValuation` that satisfies the `Bdd`.
@@ -366,7 +366,7 @@ impl Bdd {
             results.push(expression);
         }
 
-        results.last().unwrap().clone()
+        results.pop().unwrap()
     }
 
     /// Pointer to the root of the decision diagram.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ pub struct ValuationsOfClauseIterator {
 
 /// Maintains the set of variables that can appear in a `Bdd`.
 /// Used to create new `Bdd`s for basic formulas.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BddVariableSet {
     num_vars: u16,


### PR DESCRIPTION
Hi,
The intention of this PR is to introduce `Debug` for `BddVariableSet`. While I also make some other trivial improvements:
+ [optimize `last().clone()` into `pop()`](https://github.com/sybila/biodivine-lib-bdd/commit/805b78a9ade9b80af0a4542069130feae12a7c11)
+ [avoid dynamic `Read`/`Write`](https://github.com/sybila/biodivine-lib-bdd/commit/2fe8b93631b786d0daa41428dbfb43159110bc5a)

Please neglect them if you don't like. Thank you :)