### PR TITLE
Add `mk_dnf_valuation`, `mk_cnf_valuation` function

### DIFF
--- a/src/_impl_bdd/_impl_dnf.rs
+++ b/src/_impl_bdd/_impl_dnf.rs
@@ -1,4 +1,4 @@
-use crate::{Bdd, BddPartialValuation, BddPointer, BddVariable};
+use crate::{Bdd, BddPartialValuation, BddPointer, BddValuation, BddVariable};
 use num_bigint::BigInt;
 
 impl Bdd {
@@ -7,7 +7,7 @@ impl Bdd {
     /// memory copying. The disadvantage is that when the number of variables is high and the
     /// number of clauses low, this could be slightly slower due to all the recursion. However,
     /// it definitely needs to be tested at some point.
-    pub(crate) fn mk_dnf(num_vars: u16, dnf: &[BddPartialValuation]) -> Bdd {
+    pub(crate) fn mk_dnf(num_vars: u16, dnf: &[&BddPartialValuation]) -> Bdd {
         fn _rec(mut var: u16, num_vars: u16, dnf: &[&BddPartialValuation]) -> Bdd {
             loop {
                 if dnf.is_empty() {
@@ -53,8 +53,7 @@ impl Bdd {
             }
         }
 
-        let dnf_internal = Vec::from_iter(dnf.iter());
-        _rec(0, num_vars, &dnf_internal)
+        _rec(0, num_vars, dnf)
         // TODO:
         //  This algorithm works fine with fully specified clauses, but it can "explode"
         //  with partial clauses because a clause can be used by both recursive paths.
@@ -134,6 +133,52 @@ impl Bdd {
         build_recursive(num_vars, 0, &dnf, &mut result, &mut node_cache);
 
         result*/
+    }
+
+    /// [BddValuation] version of [Bdd::mk_dnf]
+    pub(crate) fn mk_dnf_valuation(num_vars: u16, dnf: &[&BddValuation]) -> Bdd {
+        fn _rec(mut var: u16, num_vars: u16, dnf: &[&BddValuation]) -> Bdd {
+            loop {
+                if dnf.is_empty() {
+                    return Bdd::mk_false(num_vars);
+                }
+                if var == num_vars || dnf.len() == 1 {
+                    let c = dnf[0];
+                    // At this point, all remaining clauses should just be duplicates.
+                    for cx in &dnf[1..] {
+                        assert_eq!(*cx, c);
+                    }
+                    return c.mk_bdd();
+                }
+
+                // If we ever get to this point, the dnf should be always either empty,
+                // or consists of a single clause.
+                assert!(var < num_vars);
+
+                let variable = BddVariable(var);
+                let should_branch = dnf.iter().any(|val| val.value(variable));
+                if !should_branch {
+                    var += 1;
+                    continue;
+                }
+
+                let mut has_true = Vec::new();
+                let mut has_false = Vec::new();
+
+                for c in dnf {
+                    match c.value(BddVariable(var)) {
+                        true => has_true.push(*c),
+                        false => has_false.push(*c),
+                    }
+                }
+
+                let has_true = _rec(var + 1, num_vars, &has_true);
+                let has_false = _rec(var + 1, num_vars, &has_false);
+
+                return has_true.or(&has_false);
+            }
+        }
+        _rec(0, num_vars, dnf)
     }
 
     /// Construct a DNF representation of this BDD. This is equivalent to collecting all results

--- a/src/_impl_bdd_partial_valuation.rs
+++ b/src/_impl_bdd_partial_valuation.rs
@@ -115,7 +115,7 @@ impl Default for BddPartialValuation {
 
 impl From<BddValuation> for BddPartialValuation {
     fn from(value: BddValuation) -> Self {
-        BddPartialValuation(value.0.into_iter().map(Some).collect::<Vec<_>>())
+        value.to_partial_valuation()
     }
 }
 

--- a/src/_impl_bdd_variable_set.rs
+++ b/src/_impl_bdd_variable_set.rs
@@ -79,21 +79,21 @@ impl BddVariableSet {
 
     /// Provides a vector of all variable names in this set, in the same order as
     /// given by [BddVariableSet::variables].
-    pub fn variable_names(&self) -> Vec<String> {
-        self.var_names.clone()
+    pub fn variable_names(&self) -> &Vec<String> {
+        &self.var_names
     }
 
     /// Provides a mapping from [BddVariable] objects to variable names.
     pub fn variable_name_assignment(&self) -> HashMap<BddVariable, String> {
         self.variables()
             .into_iter()
-            .zip(self.variable_names())
+            .zip(self.variable_names().iter().cloned())
             .collect()
     }
 
     /// Obtain the name of a specific `BddVariable`.
-    pub fn name_of(&self, variable: BddVariable) -> String {
-        self.var_names[variable.0 as usize].clone()
+    pub fn name_of(&self, variable: BddVariable) -> &str {
+        &self.var_names[variable.0 as usize]
     }
 
     /// Create a `Bdd` corresponding to the `true` formula.
@@ -226,14 +226,59 @@ impl BddVariableSet {
     /// a conjunction of such clauses. Effectively, this constructs a formula based on its
     /// conjunctive normal form.
     pub fn mk_cnf(&self, cnf: &[BddPartialValuation]) -> Bdd {
+        let cnf_internal = Vec::from_iter(cnf.iter());
+        Bdd::mk_cnf(self, &cnf_internal)
+    }
+
+    /// Interpret each `&BddPartialValuation` in `cnf` as a disjunctive clause, and produce
+    /// a conjunction of such clauses. Effectively, this constructs a formula based on its
+    /// conjunctive normal form.
+    pub fn mk_cnf_ref(&self, cnf: &[&BddPartialValuation]) -> Bdd {
         Bdd::mk_cnf(self, cnf)
+    }
+
+    /// Interpret each `BddValuation` in `cnf` as a disjunctive clause, and produce
+    /// a conjunction of such clauses. Effectively, this constructs a formula based on its
+    /// conjunctive normal form.
+    pub fn mk_cnf_valuation(&self, cnf: &[BddValuation]) -> Bdd {
+        let cnf_internal = Vec::from_iter(cnf.iter());
+        Bdd::mk_cnf_valuation(self, &cnf_internal)
+    }
+
+    /// Interpret each `&BddValuation` in `cnf` as a disjunctive clause, and produce
+    /// a conjunction of such clauses. Effectively, this constructs a formula based on its
+    /// conjunctive normal form.
+    pub fn mk_cnf_valuation_ref(&self, cnf: &[&BddValuation]) -> Bdd {
+        Bdd::mk_cnf_valuation(self, cnf)
     }
 
     /// Interpret each `BddPartialValuation` in `dnf` as a conjunctive clause, and produce
     /// a disjunction of such clauses. Effectively, this constructs a formula based on its
     /// disjunctive normal form.
     pub fn mk_dnf(&self, dnf: &[BddPartialValuation]) -> Bdd {
+        let dnf_internal = Vec::from_iter(dnf.iter());
+        Bdd::mk_dnf(self.num_vars, &dnf_internal)
+    }
+    /// Interpret each `&BddPartialValuation` in `dnf` as a conjunctive clause, and produce
+    /// a disjunction of such clauses. Effectively, this constructs a formula based on its
+    /// disjunctive normal form.
+    pub fn mk_dnf_ref(&self, dnf: &[&BddPartialValuation]) -> Bdd {
         Bdd::mk_dnf(self.num_vars, dnf)
+    }
+
+    /// Interpret each `BddPartial` in `dnf` as a conjunctive clause, and produce
+    /// a disjunction of such clauses. Effectively, this constructs a formula based on its
+    /// disjunctive normal form.
+    pub fn mk_dnf_valuation(&self, dnf: &[BddValuation]) -> Bdd {
+        let dnf_internal = Vec::from_iter(dnf.iter());
+        Bdd::mk_dnf_valuation(self.num_vars, &dnf_internal)
+    }
+
+    /// Interpret each `&BddValuation` in `dnf` as a conjunctive clause, and produce
+    /// a disjunction of such clauses. Effectively, this constructs a formula based on its
+    /// disjunctive normal form.
+    pub fn mk_dnf_valuation_ref(&self, dnf: &[&BddValuation]) -> Bdd {
+        Bdd::mk_dnf_valuation(self.num_vars, dnf)
     }
 
     /// Build a BDD that is satisfied by all valuations where *up to* $k$ `variables` are `true`.
@@ -332,7 +377,7 @@ impl BddVariableSet {
         let mut new_support_set = Vec::new();
         for var in &old_support_set {
             let name = ctx.name_of(*var);
-            let Some(id) = self.var_by_name(name.as_str()) else {
+            let Some(id) = self.var_by_name(name) else {
                 // The variable does not exist in the new context.
                 return None;
             };
@@ -522,16 +567,26 @@ mod tests {
             (variables[0], false),
         ]);
         let c3 = BddPartialValuation::from_values(&[(variables[2], true)]);
+        let formula_valuations: Vec<BddValuation> = universe
+            .mk_conjunctive_clause(&c1)
+            .sat_valuations()
+            .chain(universe.mk_conjunctive_clause(&c2).sat_valuations())
+            .chain(universe.mk_conjunctive_clause(&c3).sat_valuations())
+            .collect();
         let formula = &[c1, c2, c3];
         assert_eq!(cnf_expected, universe.mk_cnf(formula));
+        assert_eq!(cnf_expected, universe.mk_cnf_valuation(&formula_valuations));
         assert_eq!(dnf_expected, universe.mk_dnf(formula));
+        assert_eq!(dnf_expected, universe.mk_dnf_valuation(&formula_valuations));
 
         assert_eq!(universe.mk_false(), universe.mk_dnf(&[]));
+        assert_eq!(universe.mk_false(), universe.mk_dnf_valuation(&[]));
         assert_eq!(
             universe.mk_true(),
             universe.mk_dnf(&[BddPartialValuation::empty()])
         );
         assert_eq!(universe.mk_true(), universe.mk_cnf(&[]));
+        assert_eq!(universe.mk_true(), universe.mk_cnf_valuation(&[]));
         assert_eq!(
             universe.mk_false(),
             universe.mk_cnf(&[BddPartialValuation::empty()])
@@ -635,7 +690,7 @@ mod tests {
             .into_iter()
             .map(String::from)
             .collect::<Vec<_>>();
-        assert_eq!(names, ctx.variable_names());
+        assert_eq!(&names, ctx.variable_names());
         let mapping = ctx
             .variables()
             .into_iter()


### PR DESCRIPTION
Hi,

I’ve been using `Vec<BddValuation>` as a truth table and this crate works perfectly for my use case. However, I need to frequently
+ access `BddValuation::vector` just to get the truth values,
+ convert `&[&BddValuation]` to `Bdd` in DNF/CNF form,
+ convert a `&BddValuation` back to `Bdd`.

In the PR, I want to introduce following improvements,
1. New constructors for owned slices
+ `mk_dnf_valuation(&[BddValuation]) -> Bdd`
+ `mk_cnf_valuation(&[BddValuation]) -> Bdd`
(with accompanying test cases)
2. New constructors for borrowed slices
+ `mk_dnf_ref(&[&BddPartialValuation])`
+ `mk_cnf_ref(&[&BddPartialValuation])`
+ `mk_dnf_valuation_ref(&[&BddValuation])`
+ `mk_cnf_valuation_ref(&[&BddValuation])`
3. Change `BddValuation::vector` to return a reference instead of taking ownership
4. Remove unnecessary `.clone()` calls in several functions

Please let me know if you have any suggestions. Thanks!