### PR TITLE
Extend `restrict`/`select`/`exists`/`for_all` with more basic input, to avoid overhead

### DIFF
--- a/src/_impl_bdd/_impl_nested_ops.rs
+++ b/src/_impl_bdd/_impl_nested_ops.rs
@@ -17,9 +17,24 @@ impl Bdd {
         F: Fn(Option<bool>, Option<bool>) -> Option<bool>,
     {
         let set: HashSet<BddVariable, FxBuildHasher> =
-            HashSet::from_iter(variables.iter().cloned());
+            HashSet::from_iter(variables.iter().copied());
         let trigger = |var: BddVariable| set.contains(&var);
 
+        Bdd::binary_op_with_for_all_trigger(left, right, trigger, op)
+    }
+
+    /// Performs a logical operation (`op`) on two BDDs while performing a **universal projection**
+    /// on the given `variables` in the result BDD.
+    pub fn binary_op_with_for_all_trigger<F, Trigger>(
+        left: &Bdd,
+        right: &Bdd,
+        trigger: Trigger,
+        op: F,
+    ) -> Bdd
+    where
+        Trigger: Fn(BddVariable) -> bool,
+        F: Fn(Option<bool>, Option<bool>) -> Option<bool>,
+    {
         Bdd::binary_op_nested(left, right, trigger, op, crate::op_function::and)
     }
 
@@ -35,9 +50,24 @@ impl Bdd {
         F: Fn(Option<bool>, Option<bool>) -> Option<bool>,
     {
         let set: HashSet<BddVariable, FxBuildHasher> =
-            HashSet::from_iter(variables.iter().cloned());
+            HashSet::from_iter(variables.iter().copied());
         let trigger = |var: BddVariable| set.contains(&var);
 
+        Bdd::binary_op_with_exists_trigger(left, right, trigger, op)
+    }
+
+    /// Performs a logical operation (`op`) on two BDDs while performing an
+    /// **existential projection** on the given `variables` in the result BDD.
+    pub fn binary_op_with_exists_trigger<F, Trigger>(
+        left: &Bdd,
+        right: &Bdd,
+        trigger: Trigger,
+        op: F,
+    ) -> Bdd
+    where
+        Trigger: Fn(BddVariable) -> bool,
+        F: Fn(Option<bool>, Option<bool>) -> Option<bool>,
+    {
         Bdd::binary_op_nested(left, right, trigger, op, crate::op_function::or)
     }
 

--- a/src/_impl_bdd/_impl_util.rs
+++ b/src/_impl_bdd/_impl_util.rs
@@ -121,6 +121,17 @@ impl Bdd {
         }
     }
 
+    /// If this `Bdd` is a constant, convert it to `bool`, otherwise return `None`.
+    pub fn as_bool(&self) -> Option<bool> {
+        if self.is_true() {
+            Some(true)
+        } else if self.is_false() {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
     /// True if this `Bdd` is exactly the `true` formula.
     pub fn is_true(&self) -> bool {
         self.0.len() == 2
@@ -1111,6 +1122,7 @@ mod tests {
         let x_1 = vars.var_by_name("x_1").unwrap();
         let substituted = original.substitute(x_1, &to_swap);
         assert!(expected.iff(&substituted).is_true());
+        assert_eq!(expected.iff(&substituted).as_bool(), Some(true));
     }
 
     #[test]

--- a/src/_impl_bdd/_impl_util.rs
+++ b/src/_impl_bdd/_impl_util.rs
@@ -300,13 +300,13 @@ impl Bdd {
         let mut results: Vec<BooleanExpression> = Vec::with_capacity(self.0.len());
         results.push(BooleanExpression::Const(false)); // fake terminals
         results.push(BooleanExpression::Const(true)); // never used
-        for node in 2..self.0.len() {
+        for node in self.0.iter().skip(2) {
             // skip terminals
-            let node_var = self.0[node].var;
+            let node_var = node.var;
             let var_name = variables.var_names[node_var.0 as usize].clone();
 
-            let low_link = self.0[node].low_link;
-            let high_link = self.0[node].high_link;
+            let low_link = node.low_link;
+            let high_link = node.high_link;
             let expression = if low_link.is_terminal() && high_link.is_terminal() {
                 // Both links are terminal, which means this is an exactly determined variable
                 if high_link.is_one() && low_link.is_zero() {
@@ -314,7 +314,7 @@ impl Bdd {
                 } else if high_link.is_zero() && low_link.is_one() {
                     BooleanExpression::Not(Box::new(Variable(var_name)))
                 } else {
-                    panic!("Invalid node {:?} in bdd {:?}.", self.0[node], self.0);
+                    panic!("Invalid node {:?} in bdd {:?}.", node, self.0);
                 }
             } else if low_link.is_terminal() {
                 if low_link.is_zero() {
@@ -352,7 +352,7 @@ impl Bdd {
                         Box::new(results[high_link.0 as usize].clone()),
                     )),
                     Box::new(BooleanExpression::And(
-                        Box::new(BooleanExpression::Not(Box::new(Variable(var_name.clone())))),
+                        Box::new(BooleanExpression::Not(Box::new(Variable(var_name)))),
                         Box::new(results[low_link.0 as usize].clone()),
                     )),
                 )

--- a/src/_impl_bdd_partial_valuation.rs
+++ b/src/_impl_bdd_partial_valuation.rs
@@ -37,7 +37,7 @@ impl BddPartialValuation {
     /// any uniqueness checking. If the slice contains multiple copies of the same variable,
     /// the last value is accepted.
     pub fn from_values(values: &[(BddVariable, bool)]) -> BddPartialValuation {
-        Self::from_values_iter(values.into_iter().copied())
+        Self::from_values_iter(values.iter().copied())
     }
 
     /// Create a partial valuation from a list of variables and values.

--- a/src/_impl_bdd_partial_valuation.rs
+++ b/src/_impl_bdd_partial_valuation.rs
@@ -37,9 +37,20 @@ impl BddPartialValuation {
     /// any uniqueness checking. If the slice contains multiple copies of the same variable,
     /// the last value is accepted.
     pub fn from_values(values: &[(BddVariable, bool)]) -> BddPartialValuation {
+        Self::from_values_iter(values.into_iter().copied())
+    }
+
+    /// Create a partial valuation from a list of variables and values.
+    ///
+    /// The order of variables in the slice can be arbitrary. The operation does not perform
+    /// any uniqueness checking. If the slice contains multiple copies of the same variable,
+    /// the last value is accepted.
+    pub fn from_values_iter<I: Iterator<Item = (BddVariable, bool)>>(
+        values: I,
+    ) -> BddPartialValuation {
         let mut result = Self::empty();
         for (id, value) in values {
-            result.set_value(*id, *value)
+            result.set_value(id, value)
         }
         result
     }

--- a/src/_impl_bdd_valuation.rs
+++ b/src/_impl_bdd_valuation.rs
@@ -54,6 +54,11 @@ impl BddValuation {
     }
 
     /// Convert the valuation to its underlying vector.
+    pub fn as_vector_mut(&mut self) -> &mut Vec<bool> {
+        &mut self.0
+    }
+
+    /// Convert the valuation to its underlying vector.
     pub fn into_vector(self) -> Vec<bool> {
         self.0
     }

--- a/src/_impl_bdd_variable_set_builder.rs
+++ b/src/_impl_bdd_variable_set_builder.rs
@@ -50,15 +50,16 @@ impl BddVariableSetBuilder {
 
     /// Convert this builder to an actual variable set.
     pub fn build(self) -> BddVariableSet {
-        let mut mapping: HashMap<String, u16> = HashMap::new();
-        for name_index in 0..self.var_names.len() {
-            let name = self.var_names[name_index].clone();
-            mapping.insert(name, name_index as u16);
-        }
+        let var_index_mapping: HashMap<String, u16> = self
+            .var_names
+            .iter()
+            .enumerate()
+            .map(|(name_index, name)| (name.clone(), name_index as u16))
+            .collect();
         BddVariableSet {
             num_vars: self.var_names.len() as u16,
             var_names: self.var_names,
-            var_index_mapping: mapping,
+            var_index_mapping,
         }
     }
 }

--- a/src/_test_bdd/_test_bdd_logic_basic.rs
+++ b/src/_test_bdd/_test_bdd_logic_basic.rs
@@ -23,6 +23,7 @@ fn bdd_not_preserves_equivalence() {
     let not_b = variables.mk_not_var(v2());
     assert_eq!(a.not(), not_a);
     assert_eq!(bdd!(!(a & not_b)), bdd!(not_a | b));
+    assert_eq!(a.into_not(), not_a);
 }
 
 #[test]

--- a/src/boolean_expression/_impl_parser.rs
+++ b/src/boolean_expression/_impl_parser.rs
@@ -85,7 +85,8 @@ fn tokenize_group(data: &mut Peekable<Chars>, top_level: bool) -> Result<Vec<Exp
             }
             _ => {
                 // start of a variable name
-                let mut name = vec![c];
+                let mut name = String::new();
+                name.push(c);
                 while let Some(c) = data.peek() {
                     if c.is_whitespace() || NOT_IN_VAR_NAME.contains(c) {
                         break;
@@ -94,7 +95,7 @@ fn tokenize_group(data: &mut Peekable<Chars>, top_level: bool) -> Result<Vec<Exp
                         data.next(); // advance iterator
                     }
                 }
-                output.push(ExprToken::Id(name.into_iter().collect()));
+                output.push(ExprToken::Id(name));
             }
         }
     }


### PR DESCRIPTION
Hi,
I found following extensions can avoid overhead in my application. Especially when I have a custom `HashSet<BddVariable>` to preform `for_all`/`exists`, or I have a `BddPartialValuation` to preform `select`/`restrict`. 
```rust
impl Bdd {
    // take self into not
    fn into_not(self) -> Bdd;
    // use `valuation: &BddPartialValuation` for `select`/`restrict`
    fn select_valuation(&self, valuation: &BddPartialValuation) -> Bdd;
    fn restrict_valuation(&self, valuation: &BddPartialValuation) -> Bdd;
    // use `trigger: Fn(BddVariable) -> bool` for `for_all`/`exists`
    fn for_all_trigger<Trigger: Fn(BddVariable) -> bool>(&self, trigger: Trigger) -> Bdd;
    fn exists_trigger<Trigger: Fn(BddVariable) -> bool>(&self, trigger: Trigger) -> Bdd;
}
```
And there are some other trivial modifications, please have a look.
Thank you a lot :)