### PR TITLE
Uniform random sampling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.MIN_RUST_VERSION }}
       - name: cargo login
         run: |-
           echo "${{ secrets.CRATES_IO_API_TOKEN }}" | cargo login
@@ -37,6 +39,7 @@ jobs:
           cargo publish
           
   generate-notes:
+    name: Generate release notes (gemini)
     runs-on: ubuntu-latest
     needs:
       - minimum-supported
@@ -45,6 +48,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.MIN_RUST_VERSION }}
+      - name: Install cargo public API
+        run: |
+          cargo install cargo-public-api
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.MIN_RUST_VERSION }}
-      - name: Install cargo public API
-        run: |
-          cargo install cargo-public-api
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-public-api
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -77,7 +77,7 @@ jobs:
         run: |
           source .venv/bin/activate
           python -m llm_release_notes.cli --verbose synthesize \
-            --repo ${{ github.repositoryUrl }} \
+            --repo https://github.com/sybila/biodivine-lib-bdd \
             --version ${{ steps.version.outputs.tag }} \
             --output release-notes.md \
             --config .releasenotes.yml

--- a/.releasenotes.yml
+++ b/.releasenotes.yml
@@ -1,5 +1,5 @@
 project_type: library
-public_api_command: "cargo public-api --diff-no-blanket-impls"
+public_api_command: "cargo public-api --omit blanket-impls,auto-trait-impls,auto-derived-impls"
 gemini_model: "gemini-2.5-pro"
 diff_exclude_paths:
   - res/**

--- a/.releasenotes.yml
+++ b/.releasenotes.yml
@@ -1,0 +1,5 @@
+project_type: library
+public_api_command: "cargo public-api --diff-no-blanket-impls"
+gemini_model: "gemini-2.5-pro"
+diff_exclude_paths:
+  - res/**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ fxhash = "0.2.1"
 rand = "0.8" # TODO: Can't update `rand` until supported by `num-bigint`.
 num-bigint = {  version = "0.4.6", features = ["rand"] }
 num-traits = "0.2.19"
+num-rational = "0.4.2"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Enable rich docs for some online docs autogen services.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 fxhash = "0.2.1"
-rand = "0.9.2"
-num-bigint = "0.4.6"
+rand = "0.8" # TODO: Can't update `rand` until supported by `num-bigint`.
+num-bigint = {  version = "0.4.6", features = ["rand"] }
 num-traits = "0.2.19"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 

--- a/examples/bench_restrict.rs
+++ b/examples/bench_restrict.rs
@@ -19,7 +19,7 @@ fn main() {
         support.shuffle(&mut rng);
 
         for var in &support[0..k] {
-            reduction[*var] = Some(rng.random_bool(0.5));
+            reduction[*var] = Some(rng.gen_bool(0.5));
         }
 
         // Run restriction.

--- a/src/_impl_bdd/_impl_relation_ops.rs
+++ b/src/_impl_bdd/_impl_relation_ops.rs
@@ -110,7 +110,7 @@ impl Bdd {
     /// Note that this is not the same as having a random value picked on each path in the `Bdd`.
     /// Instead, there is one "global" value that is preferred on every path.
     pub fn var_pick_random<R: Rng>(&self, variable: BddVariable, rng: &mut R) -> Bdd {
-        let preferred = self.var_select(variable, rng.random_bool(0.5));
+        let preferred = self.var_select(variable, rng.gen_bool(0.5));
         Bdd::fused_binary_flip_op(
             (self, None),
             (&preferred, Some(variable)),

--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -318,14 +318,14 @@ impl Bdd {
             let var = BddVariable(i_var);
             if self.var_of(node) != var {
                 // Just pick random.
-                valuation.set_value(var, rng.random_bool(0.5));
+                valuation.set_value(var, rng.gen_bool(0.5));
             } else {
                 let child = if self.low_link_of(node).is_zero() {
                     true
                 } else if self.high_link_of(node).is_zero() {
                     false
                 } else {
-                    rng.random_bool(0.5)
+                    rng.gen_bool(0.5)
                 };
 
                 valuation.set_value(var, child);
@@ -358,7 +358,7 @@ impl Bdd {
             } else if self.high_link_of(node).is_zero() {
                 false
             } else {
-                rng.random_bool(0.5)
+                rng.gen_bool(0.5)
             };
 
             path.set_value(self.var_of(node), child);

--- a/src/_impl_bdd/_impl_valuation_utils.rs
+++ b/src/_impl_bdd/_impl_valuation_utils.rs
@@ -306,7 +306,9 @@ impl Bdd {
     /// generator.
     ///
     /// Note that the random distribution with which the valuations are picked depends
-    /// on the structure of the `Bdd` and is not necessarily uniform.
+    /// on the structure of the `Bdd` and is not necessarily uniform. To implement true
+    /// uniform valuation sampling, see [`Bdd::random_valuation_sample`] and
+    /// [`Bdd::mk_uniform_valuation_sampler`]
     pub fn random_valuation<R: Rng>(&self, rng: &mut R) -> Option<BddValuation> {
         if self.is_false() {
             return None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ use std::collections::{HashMap, HashSet};
 
 pub mod boolean_expression;
 pub mod op_function;
+pub mod random_sampling;
 pub mod tutorial;
 
 /// **(internal)** Implementations for the `Bdd` struct.

--- a/src/random_sampling.rs
+++ b/src/random_sampling.rs
@@ -1,0 +1,285 @@
+use crate::{Bdd, BddPointer, BddValuation, BddVariable};
+use num_bigint::BigInt;
+use num_rational::BigRational;
+use num_traits::{One, ToPrimitive, Zero};
+use rand::Rng;
+
+/// Describes a method that can be used to sample a random valuation from a [`Bdd`]
+/// by sampling random Boolean values for given BDD nodes and skipped variables.
+pub trait SamplingMethod {
+    /// Sample a random Boolean value for the given BDD node.
+    ///
+    /// The method takes a mutable reference to `self` to allow for something like [`Rng`]
+    /// to be stored in the struct.
+    fn sample_decision_node(&mut self, node: BddPointer) -> bool;
+
+    /// Sample a random Boolean value for a variable that does not have a decision node. This
+    /// method is not used when sampling paths, it is only required to sample valuations.
+    ///
+    /// The method takes a mutable reference to `self` to allow for something like [`Rng`]
+    /// to be stored in the struct.
+    fn sample_skipped_node(&mut self, var: BddVariable) -> bool;
+}
+
+/// Sampling which always uses probability 1/2, but ignores BDD structure, meaning the
+/// final distribution of results depends heavily on the structure of the BDD.
+///
+/// ```
+/// # use biodivine_lib_bdd::BddVariableSet;
+/// # use biodivine_lib_bdd::random_sampling::NaiveSampler;
+/// # let set = BddVariableSet::new_anonymous(4);
+/// # let bdd = set.eval_expression_string("x_0 & x_1 | x_3");
+/// let rng = rand::thread_rng();
+/// let mut sampling = NaiveSampler::from(rng);
+/// let _ = bdd.random_valuation_sample(&mut sampling);
+/// ```
+pub struct NaiveSampler<R: Rng + Sized>(R);
+
+impl<R: Rng + Sized> From<R> for NaiveSampler<R> {
+    fn from(value: R) -> Self {
+        NaiveSampler(value)
+    }
+}
+
+impl<R: Rng + Sized> SamplingMethod for NaiveSampler<R> {
+    fn sample_decision_node(&mut self, _node: BddPointer) -> bool {
+        self.0.gen_bool(0.5)
+    }
+
+    fn sample_skipped_node(&mut self, _var: BddVariable) -> bool {
+        self.0.gen_bool(0.5)
+    }
+}
+
+/// Sampling that uses a pre-computed vector of bias values to ensure that random sampling
+/// is performed in a way that produces a **uniform distribution over the valuations** of the BDD.
+///
+/// **Note that every instance of uniform sampling is built specifically for the given BDD and
+/// only works with this BDD.**
+///
+/// ```
+/// # use biodivine_lib_bdd::BddVariableSet;
+/// # use biodivine_lib_bdd::random_sampling::{NaiveSampler, UniformValuationSampler};
+/// # let set = BddVariableSet::new_anonymous(4);
+/// # let bdd = set.eval_expression_string("x_0 & x_1 | x_3");
+/// let rng = rand::thread_rng();
+/// let mut sampling = bdd.mk_uniform_valuation_sampler(rng);
+/// let _ = bdd.random_valuation_sample(&mut sampling);
+/// ```
+pub struct UniformValuationSampler<R: Rng + Sized> {
+    rng: R,
+    ratios: Vec<BigRational>,
+}
+
+impl<R: Rng + Sized> SamplingMethod for UniformValuationSampler<R> {
+    fn sample_decision_node(&mut self, node: BddPointer) -> bool {
+        sample_big_rational_probability(&mut self.rng, &self.ratios[node.to_index()])
+    }
+
+    fn sample_skipped_node(&mut self, _var: BddVariable) -> bool {
+        self.rng.gen_bool(0.5) // Skipped nodes are already uniform.
+    }
+}
+
+impl Bdd {
+    /// Build an instance of [`UniformValuationSampler`] specifically for this [`Bdd`].
+    pub fn mk_uniform_valuation_sampler<R: Rng + Sized>(
+        &self,
+        rng: R,
+    ) -> UniformValuationSampler<R> {
+        let zero = BigInt::zero();
+        let one = BigInt::one();
+        let two = BigInt::from(2u32);
+        let half = BigRational::new(one.clone(), two.clone());
+
+        let mut ratios = vec![half; self.size()];
+
+        let mut valuation_count = vec![None; self.0.len()];
+        valuation_count[0] = Some(zero.clone());
+        valuation_count[1] = Some(one.clone());
+
+        let mut stack: Vec<BddPointer> = vec![self.root_pointer()];
+        while let Some(node) = stack.last() {
+            if valuation_count[node.to_index()].is_some() {
+                stack.pop();
+            } else {
+                let low_pointer = self.low_link_of(*node);
+                let high_pointer = self.high_link_of(*node);
+                let low_var = self.var_of(low_pointer).0;
+                let high_var = self.var_of(high_pointer).0;
+                let node_var = self.var_of(*node).0;
+                let low = low_pointer.to_index();
+                let high = high_pointer.to_index();
+
+                if let (Some(cache_low), Some(cache_high)) =
+                    (&valuation_count[low], &valuation_count[high])
+                {
+                    let low_card = cache_low * (one.clone() << (low_var - node_var - 1));
+                    let high_card = cache_high * (one.clone() << (high_var - node_var - 1));
+                    let total_card = &low_card + &high_card;
+                    valuation_count[node.to_index()] = Some(total_card.clone());
+                    ratios[node.to_index()] = BigRational::new(high_card.clone(), total_card);
+                    stack.pop();
+                } else {
+                    if valuation_count[low].is_none() {
+                        stack.push(low_pointer);
+                    }
+                    if valuation_count[high].is_none() {
+                        stack.push(high_pointer);
+                    }
+                }
+            }
+        }
+
+        UniformValuationSampler { rng, ratios }
+    }
+
+    /// Sample a random [`BddValuation`] from this BDD using the provided [`SamplingMethod`].
+    ///
+    /// Typically, this is either [`NaiveSampler`] (faster, but provides no guarantees
+    /// on the distribution of the output data) or [`UniformValuationSampler`] (slower,
+    /// but provides guaranteed uniform distribution over all values in the BDD).
+    ///
+    /// Returns `None` if the BDD is not satisfiable.
+    pub fn random_valuation_sample<S: SamplingMethod>(
+        &self,
+        sampling_method: &mut S,
+    ) -> Option<BddValuation> {
+        if self.is_false() {
+            return None;
+        }
+
+        let mut valuation = BddValuation::all_false(self.num_vars());
+        let mut node = self.root_pointer();
+        for i_var in 0..self.num_vars() {
+            let var = BddVariable(i_var);
+            if self.var_of(node) != var {
+                // Just pick random.
+                valuation.set_value(var, sampling_method.sample_skipped_node(var));
+            } else {
+                let child = if self.low_link_of(node).is_zero() {
+                    true
+                } else if self.high_link_of(node).is_zero() {
+                    false
+                } else {
+                    sampling_method.sample_decision_node(node)
+                };
+
+                valuation.set_value(var, child);
+                node = if child {
+                    self.high_link_of(node)
+                } else {
+                    self.low_link_of(node)
+                }
+            }
+        }
+
+        Some(valuation)
+    }
+}
+
+/// Samples a boolean value where the probability of getting `true` is equal to `prob`.
+///
+/// The input `prob` must be an arbitrary precision rational number between 0 and 1 (inclusive).
+///
+/// # Arguments
+///
+/// * `rng` - A mutable reference to a random number generator implementing `rand::Rng`.
+/// * `prob` - The `BigRational` representing the probability of returning `true`.
+///
+/// # Panics
+///
+/// Panics if `prob` is not between 0 and 1 (inclusive), or if its denominator is zero.
+/// (The `BigRational` type itself usually prevents a zero denominator).
+fn sample_big_rational_probability<R: Rng + ?Sized>(rng: &mut R, prob: &BigRational) -> bool {
+    // If the rational can be successfully represented as a `u32` ratio, we can use primitives.
+    if let (Some(numer), Some(denom)) = (prob.numer().to_u32(), prob.denom().to_u32()) {
+        return rng.gen_ratio(numer, denom);
+    }
+
+    let n = prob.numer(); // Numerator
+    let d = prob.denom(); // Denominator
+
+    // A BigRational is usually reduced, so denom should be positive.
+    if d.is_zero() {
+        panic!("Invariant violation: Denominator cannot be zero.");
+    }
+
+    // Check if 0 <= prob <= 1
+    if n < &BigInt::zero() || n > d {
+        panic!("Probability must be between 0 and 1 inclusive.");
+    }
+
+    // Edge cases for probability 0 or 1
+    if n.is_zero() {
+        return false;
+    }
+    if n == d {
+        // Since 0 <= prob <= 1, if n == d, prob must be 1
+        return true;
+    }
+
+    // Generate a random BigInt `r_int` in the range [0, d-1]
+    // `gen_range(low..high)` generates in `[low, high)`
+    // Note: We need to clone `d` because `gen_range` takes `self` by value.
+    let r_int = rng.gen_range(BigInt::zero()..d.clone());
+
+    // Check if `r_int` is less than `n`
+    r_int < *n
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::random_sampling::NaiveSampler;
+    use crate::{BddValuation, BddVariable, BddVariableSet};
+
+    #[test]
+    fn test_uniform_sampling() {
+        let set = BddVariableSet::new_anonymous(4);
+
+        // The BDD has 2^3 + 1 satisfying valuations, so the likelihood of sampling (0,0,1,1)
+        // should approach `0.11111`.
+        let bdd = set.eval_expression_string("x_0 | (!x_0 & !x_1 & x_2 & x_3)");
+
+        let mut target = BddValuation::all_false(4);
+        target[BddVariable::from_index(2)] = true;
+        target[BddVariable::from_index(3)] = true;
+
+        // First, test uniform sampling:
+
+        let rng = rand::thread_rng();
+        let mut uniform = bdd.mk_uniform_valuation_sampler(rng);
+
+        let mut found = 0u32;
+        for _ in 0..10_000 {
+            let valuation = bdd.random_valuation_sample(&mut uniform).unwrap();
+            if valuation == target {
+                found += 1;
+            }
+        }
+
+        // In theory, this is fully random and can return anything. In practice, we expect
+        // the result to be within 20% of the expected value, which is 1_111.
+        assert!(found > 888 && found < 1_333, "{} not in [888, 1333]", found);
+
+        // Now compare it to naive sampling:
+        let rng = rand::thread_rng();
+        let mut naive = NaiveSampler::from(rng);
+
+        let mut found = 0u32;
+        for _ in 0..10_000 {
+            let valuation = bdd.random_valuation_sample(&mut naive).unwrap();
+            if valuation == target {
+                found += 1;
+            }
+        }
+
+        // In theory, this is fully random and can return anything. In practice, we expect
+        // the result to be within 20% of the expected value, which is 5000.
+        assert!(
+            found > 4000 && found < 6000,
+            "{} not in [4000, 6000]",
+            found
+        );
+    }
+}


### PR DESCRIPTION
Allows to sample valuations from a BDD based on the uniform distribution (i.e. independent of the BDD structure).

Unfortunately, we had to downgrade `rand` back to `0.8` for this, because random generator of `BigInt` values is only available for `rand=0.8` right now.